### PR TITLE
AuthEndpoints 3.0 RC: Identity/Passkey hardening and opinionated facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![issues](https://img.shields.io/github/issues/madeyoga/AuthEndpoints?color=blue&logo=github&style=flat-square)](https://github.com/madeyoga/AuthEndpoints/issues)
 [![downloads](https://img.shields.io/nuget/dt/AuthEndpoints?color=blue&style=flat-square&logo=nuget)](https://www.nuget.org/packages/AuthEndpoints/)
 ![workflow](https://github.com/madeyoga/AuthEndpoints/actions/workflows/dotnet.yml/badge.svg)
-<!-- [![CodeFactor](https://codefactor.io/repository/github/madeyoga/authendpoints/badge)](https://www.codefactor.io/repository/github/madeyoga/authendpoints) -->
 [![license](https://img.shields.io/github/license/madeyoga/AuthEndpoints?color=blue&style=flat-square&logo=github)](https://github.com/madeyoga/AuthEndpoints/blob/main/LICENSE)
 
 A simple auth library for ASP.NET Core. AuthEndpoints provides minimal API endpoints for registration, email verification, password reset, login/logout, 2FA, JWT, and passkeys (WebAuthn).
@@ -12,91 +11,91 @@ A simple auth library for ASP.NET Core. AuthEndpoints provides minimal API endpo
 
 ## Endpoints
 
-- **Cookie / Bearer Identity** (`MapCookieAuthEndpoints` / `MapBearerAuthEndpoints`)
+- **Opinionated bundle** (`AddAuthEndpoints` / `UseAuthEndpoints` / `MapAuthEndpoints`)
+  - Cookie Identity at `/identity` + passkeys at `/account` by default
+  - Secure Identity defaults, antiforgery, ReAuth, rate limiting
+- **Cookie / Bearer Identity** (`MapCookieAuthEndpoints` / `MapBearerAuthEndpoints`) — advanced composition
   - register, confirm email, login, logout
-  - forgot / reset password, account info
-  - 2FA manage
-  - reauth (`confirmIdentity`, `confirmIdentity/passkeyOptions`, `manage/authMethods`)
-- **Simple JWT** (`MapJwtAuthEndpoints`)
-  - create (login), refresh, verify
-  - when 2FA is enabled, `create` requires `twoFactorCode` or `twoFactorRecoveryCode`
-- **Passkeys** (`MapPasskeyEndpoints`)
-  - creation / request options
-  - passwordless register + login
-  - list / add / rename / delete credentials
+  - forgot / reset password, account info, 2FA, reauth
+- **Simple JWT** (`MapJwtAuthEndpoints`) — advanced composition
+- **Passkeys** (`MapPasskeyEndpoints`) — advanced composition
 
 ## Installing via NuGet
 
 ```
-dotnet add package AuthEndpoints --version 3.0.0-alpha.10
+dotnet add package AuthEndpoints --version 3.0.0-alpha.11
 ```
 
-## Quick start
+## Quick start (recommended)
 
 ```cs
 // Program.cs
+builder.Services.AddDbContext<AppDbContext>(/* your provider */);
+
+builder.Services.AddAuthEndpoints<AppUser, AppDbContext>(o =>
+{
+    o.Passkeys.ServerDomain = "example.com"; // required in Production
+});
+
+// Required in Production (Identity's no-op sender is rejected).
+builder.Services.AddTransient<IEmailSender<AppUser>, MyEmailSender>();
+
+var app = builder.Build();
+
+app.UseAuthEndpoints(); // authentication, authorization, rate limiting, antiforgery
+app.MapAuthEndpoints<AppUser>(); // /identity (cookie) + /account (passkeys)
+
+app.Run();
+```
+
+Use HTTPS in Production. The facade fails startup in Production if `Passkeys.ServerDomain` is missing (when passkeys are enabled) or if no real `IEmailSender<TUser>` is registered.
+
+### Reauthentication (step-up)
+
+Mapped with cookie Identity:
+
+1. `GET /identity/manage/authMethods`
+2. `POST /identity/confirmIdentity` with exactly one of: `password`, `twoFactorCode`, `twoFactorRecoveryCode`, `credentialJson`
+3. Cookie clients receive an `AuthEndpoints.ReAuth` cookie; API clients also get `reauthToken` for the `X-AuthEndpoints-Reauth` header
+
+### Passkey passwordless flow
+
+1. `POST /account/passkeys/register/options` with `{ "email": "..." }`
+2. Browser `navigator.credentials.create(...)`
+3. `POST /account/passkeys/register` with `{ "email": "...", "credentialJson": "..." }`
+
+## Advanced composition
+
+Compose modules yourself when you need bearer Identity, custom paths, or JWT:
+
+```cs
 builder.Services
     .AddIdentityApiEndpoints<AppUser>(o =>
     {
-        o.Stores.SchemaVersion = IdentitySchemaVersions.Version3; // required for passkeys
+        o.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
     })
     .AddEntityFrameworkStores<AppDbContext>()
     .AddDefaultTokenProviders();
 
-builder.Services.Configure<IdentityPasskeyOptions>(options =>
-{
-    options.ServerDomain = "example.com"; // your relying-party domain
-});
-
-builder.Services.AddJwtEndpoints<AppUser, AppDbContext>(options =>
-{
-    // Required: set a stable secret (do not leave unset).
-    options.SigningOptions.SymmetricKey = builder.Configuration["Jwt:SymmetricKey"];
-});
-
 builder.Services.AddAntiforgery();
-builder.Services.AddCookieAuthEndpoints(); // ReAuth + login rate limits
-builder.Services.AddPasskeyEndpoints();    // passkey rate limits (+ ReAuth if not already added)
+builder.Services.AddCookieAuthEndpoints();
+builder.Services.AddPasskeyEndpoints();
+builder.Services.AddJwtEndpoints<AppUser, AppDbContext>(o =>
+{
+    o.SigningOptions.SymmetricKey = builder.Configuration["Jwt:SymmetricKey"];
+});
 
 var app = builder.Build();
-
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseRateLimiter();
 app.UseAntiforgery();
 
 app.MapGroup("/identity").MapCookieAuthEndpoints<AppUser>();
-app.MapGroup("/auth").MapJwtAuthEndpoints<AppUser>();
+app.MapGroup("/identity/bearer").MapBearerAuthEndpoints<AppUser>();
 app.MapGroup("/account").MapPasskeyEndpoints<AppUser>();
-
-app.Run();
+app.MapGroup("/auth").MapJwtAuthEndpoints<AppUser>();
 ```
-
-### Passkey passwordless flow
-
-1. `POST /account/passkeys/register/options` with `{ "email": "..." }` → WebAuthn creation options  
-2. Browser `navigator.credentials.create(...)`  
-3. `POST /account/passkeys/register` with `{ "email": "...", "credentialJson": "..." }` → account + passkey  
-
-Sign-in after register/login matches Identity password login:
-
-- Default (no query flags): Identity **bearer** tokens (`AccessTokenResponse`)
-- `?useCookies=true`: persistent application cookie
-- `?useSessionCookies=true`: session application cookie
-
-CSRF (antiforgery) is required on these endpoints for anonymous and cookie-authenticated clients. Bearer-only authenticated calls (Identity bearer or JWT `Bearer`) may omit the CSRF token on endpoints that use `RequireAntiforgery`. This does **not** issue Simple JWT — call `/auth/create` separately if you use `MapJwtAuthEndpoints`.
-
-For an existing signed-in user (with reauth): `POST /account/passkeys/creationOptions` then `POST /account/passkeys`.
-
-### Reauthentication (step-up)
-
-Mapped automatically with cookie/bearer Identity groups:
-
-1. `GET /identity/manage/authMethods` — which proofs the user can use (`password`, `authenticator`, `recoveryCodes`, `passkeys`)
-2. For passkey step-up: `POST /identity/confirmIdentity/passkeyOptions` → WebAuthn `get` → `POST /identity/confirmIdentity` with `{ "credentialJson": "..." }`
-3. Or confirm with exactly one of: `password`, `twoFactorCode`, `twoFactorRecoveryCode`, `credentialJson`
-
-Success issues a short-lived `AuthEndpoints.ReAuth` cookie (5 minutes) for endpoints that use `RequireReauth()`.
 
 ## Documentations
 

--- a/src/AuthEndpoints/AuthEndpoints.csproj
+++ b/src/AuthEndpoints/AuthEndpoints.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Description>Auth library that provides a set of minimal api endpoints to handle authentication actions</Description>
-    <Version>3.0.0-alpha.11</Version>
+    <Version>3.0.0-rc.1</Version>
     <Authors>madeyoga</Authors>
     <Company>madeyoga</Company>
     <PackageProjectUrl>https://github.com/madeyoga/AuthEndpoints</PackageProjectUrl>

--- a/src/AuthEndpoints/AuthEndpointsApplicationBuilderExtensions.cs
+++ b/src/AuthEndpoints/AuthEndpointsApplicationBuilderExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace AuthEndpoints;
+
+public static class AuthEndpointsApplicationBuilderExtensions
+{
+    private const string PipelineMarkerKey = "__AuthEndpoints.Pipeline";
+
+    /// <summary>
+    /// Adds the AuthEndpoints middleware pipeline in the required order:
+    /// authentication, authorization, rate limiting, antiforgery.
+    /// Call after exception-handling middleware. Hosts should enable HTTPS in Production separately.
+    /// Safe to call once; a second call is a no-op.
+    /// </summary>
+    public static IApplicationBuilder UseAuthEndpoints(this IApplicationBuilder app)
+    {
+        if (app.Properties.ContainsKey(PipelineMarkerKey))
+        {
+            return app;
+        }
+
+        app.Properties[PipelineMarkerKey] = true;
+
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseRateLimiter();
+        app.UseAntiforgery();
+
+        return app;
+    }
+}

--- a/src/AuthEndpoints/AuthEndpointsEndpointRouteBuilderExtensions.cs
+++ b/src/AuthEndpoints/AuthEndpointsEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,39 @@
+using AuthEndpoints.Identity;
+using AuthEndpoints.Passkey;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace AuthEndpoints;
+
+public static class AuthEndpointsEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps the opinionated auth surface: cookie Identity at <see cref="AuthEndpointsOptions.IdentityPath"/>
+    /// and (when enabled) passkeys at <see cref="AuthEndpointsOptions.PasskeyPath"/>.
+    /// For advanced composition use <c>MapCookieAuthEndpoints</c>, <c>MapBearerAuthEndpoints</c>,
+    /// <c>MapPasskeyEndpoints</c>, or <c>MapJwtAuthEndpoints</c> instead.
+    /// </summary>
+    public static IEndpointRouteBuilder MapAuthEndpoints<TUser>(this IEndpointRouteBuilder endpoints)
+        where TUser : class, new()
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var options = endpoints.ServiceProvider.GetRequiredService<IOptions<AuthEndpointsOptions>>().Value;
+
+        endpoints.MapGroup(options.IdentityPath)
+            .MapCookieAuthEndpoints<TUser>()
+            .WithTags("Identity");
+
+        if (options.Passkeys.Enabled)
+        {
+            endpoints.MapGroup(options.PasskeyPath)
+                .MapPasskeyEndpoints<TUser>()
+                .WithTags("Passkeys");
+        }
+
+        return endpoints;
+    }
+}

--- a/src/AuthEndpoints/AuthEndpointsOptions.cs
+++ b/src/AuthEndpoints/AuthEndpointsOptions.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace AuthEndpoints;
+
+/// <summary>
+/// Options for the opinionated <c>AddAuthEndpoints</c> / <c>UseAuthEndpoints</c> / <c>MapAuthEndpoints</c> facade.
+/// </summary>
+public sealed class AuthEndpointsOptions
+{
+    /// <summary>Route prefix for cookie Identity endpoints. Default: <c>/identity</c>.</summary>
+    public string IdentityPath { get; set; } = "/identity";
+
+    /// <summary>Route prefix for passkey endpoints. Default: <c>/account</c>.</summary>
+    public string PasskeyPath { get; set; } = "/account";
+
+    /// <summary>When true, Identity requires a confirmed account before sign-in. Default: <c>true</c>.</summary>
+    public bool RequireConfirmedAccount { get; set; } = true;
+
+    /// <summary>Passkey (WebAuthn) settings for the default bundle.</summary>
+    public AuthEndpointsPasskeyOptions Passkeys { get; set; } = new();
+
+    /// <summary>Optional Identity options customization applied after secure defaults.</summary>
+    public Action<IdentityOptions>? ConfigureIdentity { get; set; }
+
+    /// <summary>Optional passkey options customization applied after <see cref="AuthEndpointsPasskeyOptions.ServerDomain"/>.</summary>
+    public Action<IdentityPasskeyOptions>? ConfigurePasskeys { get; set; }
+
+    /// <summary>
+    /// When true (default), Production hosts must register a real <c>IEmailSender&lt;TUser&gt;</c>
+    /// (not the Identity no-op). Development is not checked.
+    /// </summary>
+    public bool RequireEmailSenderInProduction { get; set; } = true;
+}
+
+/// <summary>Passkey-related options for the opinionated facade.</summary>
+public sealed class AuthEndpointsPasskeyOptions
+{
+    /// <summary>When false, passkey DI and mapping are skipped. Default: <c>true</c>.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// WebAuthn relying-party domain (e.g. <c>example.com</c>).
+    /// Required in Production when <see cref="Enabled"/> is true.
+    /// </summary>
+    public string? ServerDomain { get; set; }
+}

--- a/src/AuthEndpoints/AuthEndpointsOptionsValidator.cs
+++ b/src/AuthEndpoints/AuthEndpointsOptionsValidator.cs
@@ -1,0 +1,88 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace AuthEndpoints;
+
+internal sealed class AuthEndpointsOptionsValidator : IValidateOptions<AuthEndpointsOptions>
+{
+    private readonly IHostEnvironment _environment;
+
+    public AuthEndpointsOptionsValidator(IHostEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    public ValidateOptionsResult Validate(string? name, AuthEndpointsOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.IdentityPath) || !options.IdentityPath.StartsWith('/'))
+        {
+            return ValidateOptionsResult.Fail("AuthEndpoints: IdentityPath must be a rooted path (e.g. \"/identity\").");
+        }
+
+        if (options.Passkeys.Enabled &&
+            (string.IsNullOrWhiteSpace(options.PasskeyPath) || !options.PasskeyPath.StartsWith('/')))
+        {
+            return ValidateOptionsResult.Fail("AuthEndpoints: PasskeyPath must be a rooted path (e.g. \"/account\").");
+        }
+
+        if (_environment.IsProduction()
+            && options.Passkeys.Enabled
+            && string.IsNullOrWhiteSpace(options.Passkeys.ServerDomain))
+        {
+            return ValidateOptionsResult.Fail(
+                "AuthEndpoints: Passkeys.ServerDomain must be set in Production when Passkeys.Enabled is true " +
+                "(e.g. options.Passkeys.ServerDomain = \"example.com\").");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}
+
+/// <summary>
+/// Production check for a real <see cref="IEmailSender{TUser}"/> (not the Identity no-op).
+/// </summary>
+internal sealed class AuthEndpointsEmailSenderValidator<TUser> : IValidateOptions<AuthEndpointsOptions>
+    where TUser : class
+{
+    private readonly IHostEnvironment _environment;
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public AuthEndpointsEmailSenderValidator(
+        IHostEnvironment environment,
+        IServiceScopeFactory scopeFactory)
+    {
+        _environment = environment;
+        _scopeFactory = scopeFactory;
+    }
+
+    public ValidateOptionsResult Validate(string? name, AuthEndpointsOptions options)
+    {
+        if (!_environment.IsProduction() || !options.RequireEmailSenderInProduction)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var sender = scope.ServiceProvider.GetService<IEmailSender<TUser>>();
+        if (sender is null || IsFrameworkEmailSender(sender))
+        {
+            return ValidateOptionsResult.Fail(
+                "AuthEndpoints: A real IEmailSender<TUser> must be registered in Production " +
+                "(the Identity no-op sender is not allowed). " +
+                "Example: services.AddTransient<IEmailSender<AppUser>, MyEmailSender>(); " +
+                "Or set RequireEmailSenderInProduction = false to opt out (not recommended).");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+
+    private static bool IsFrameworkEmailSender(IEmailSender<TUser> sender)
+    {
+        var assemblyName = sender.GetType().Assembly.GetName().Name ?? string.Empty;
+        return assemblyName.StartsWith("Microsoft.AspNetCore.Identity", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Microsoft.Extensions.Identity", StringComparison.Ordinal)
+            || sender.GetType().Name.Contains("NoOp", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/AuthEndpoints/AuthEndpointsServiceCollectionExtensions.cs
+++ b/src/AuthEndpoints/AuthEndpointsServiceCollectionExtensions.cs
@@ -1,0 +1,74 @@
+﻿using AuthEndpoints.Identity;
+using AuthEndpoints.Passkey;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace AuthEndpoints;
+
+public static class AuthEndpointsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a auth stack: Identity API endpoints, EF stores, antiforgery,
+    /// ReAuth, rate limiting, and (by default) passkey support.
+    /// Hosts must still register <see cref="DbContext"/>, call <see cref="AuthEndpointsApplicationBuilderExtensions.UseAuthEndpoints"/>,
+    /// <see cref="AuthEndpointsEndpointRouteBuilderExtensions.MapAuthEndpoints{TUser}"/>, and in Production
+    /// provide a real <c>IEmailSender&lt;TUser&gt;</c> plus <c>Passkeys.ServerDomain</c>.
+    /// </summary>
+    /// <returns>The <see cref="IdentityBuilder"/> for optional chaining (e.g. <c>AddRoles</c>).</returns>
+    public static IdentityBuilder AddAuthEndpoints<TUser, TContext>(
+        this IServiceCollection services,
+        Action<AuthEndpointsOptions>? configure = null)
+        where TUser : class, new()
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var bootstrap = new AuthEndpointsOptions();
+        configure?.Invoke(bootstrap);
+
+        services.AddOptions<AuthEndpointsOptions>()
+            .Configure(o =>
+            {
+                configure?.Invoke(o);
+            })
+            .ValidateOnStart();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<AuthEndpointsOptions>, AuthEndpointsOptionsValidator>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<AuthEndpointsOptions>, AuthEndpointsEmailSenderValidator<TUser>>());
+
+        var identityBuilder = services
+            .AddIdentityApiEndpoints<TUser>(identity =>
+            {
+                identity.SignIn.RequireConfirmedAccount = bootstrap.RequireConfirmedAccount;
+                // Version3 is required for passkey credential storage.
+                identity.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
+                bootstrap.ConfigureIdentity?.Invoke(identity);
+            })
+            .AddEntityFrameworkStores<TContext>()
+            .AddDefaultTokenProviders();
+
+        services.AddAuthorization();
+        services.AddAntiforgery();
+        services.AddCookieAuthEndpoints();
+
+        if (bootstrap.Passkeys.Enabled)
+        {
+            services.AddPasskeyEndpoints();
+            services.Configure<IdentityPasskeyOptions>(passkeys =>
+            {
+                if (!string.IsNullOrWhiteSpace(bootstrap.Passkeys.ServerDomain))
+                {
+                    passkeys.ServerDomain = bootstrap.Passkeys.ServerDomain;
+                }
+
+                bootstrap.ConfigurePasskeys?.Invoke(passkeys);
+            });
+        }
+
+        return identityBuilder;
+    }
+}

--- a/src/AuthEndpoints/Identity/AuthEndpointsConstants.cs
+++ b/src/AuthEndpoints/Identity/AuthEndpointsConstants.cs
@@ -3,9 +3,14 @@ namespace AuthEndpoints.Identity;
 public class AuthEndpointsConstants
 {
     private const string Prefix = "AuthEndpoints";
+
     public const string ReAuthScheme = Prefix + ".ReAuth";
+    public const string ReAuthBearerScheme = Prefix + ".ReAuth.Bearer";
+    public const string ReAuthHeaderName = "X-AuthEndpoints-Reauth";
+
     public const string PasskeyObtainOptionsPolicy = Prefix + ".Passkey.ObtainOptions";
     public const string PasskeyRegisterPolicy = Prefix + ".Passkey.Register";
     public const string LoginPolicy = Prefix + ".Login";
+    public const string AccountAbusePolicy = Prefix + ".AccountAbuse";
+    public const string ConfirmIdentityPolicy = Prefix + ".ConfirmIdentity";
 }
-

--- a/src/AuthEndpoints/Identity/IdentityApiEndpointRouteBuilderExtensions.cs
+++ b/src/AuthEndpoints/Identity/IdentityApiEndpointRouteBuilderExtensions.cs
@@ -9,9 +9,8 @@ namespace AuthEndpoints.Identity;
 public static class IdentityApiEndpointRouteBuilderExtensions
 {
     /// <summary>
-    /// Maps AuthEndpoints version of <c>MapIdentityApi</c>.
-    /// This method copy parts of the built-in IdentityApiEndpoints
-    /// and add more features to it.
+    /// Maps AuthEndpoints version of <c>MapIdentityApi</c> for bearer-token clients.
+    /// Call <see cref="ServiceCollectionExtensions.AddBearerAuthEndpoints"/> and <c>UseRateLimiter()</c>.
     /// </summary>
     public static IEndpointConventionBuilder MapBearerAuthEndpoints<TUser>(this IEndpointRouteBuilder endpoints)
         where TUser : class, new()
@@ -24,9 +23,11 @@ public static class IdentityApiEndpointRouteBuilderExtensions
             HttpContext context,
             IServiceProvider sp) => IdentityApiEndpoints<TUser>.Register(registration, context, sp, confirmEmailEndpointName))
             .WithSummary("Registers a new user account.")
-            .WithDescription("Creates a new user and sends a confirmation email if configured.");
+            .WithDescription("Creates a new user and sends a confirmation email if configured.")
+            .RequireRateLimiting(AuthEndpointsConstants.AccountAbusePolicy);
 
-        routeGroup.MapPost("/login", IdentityApiEndpoints<TUser>.Login);
+        routeGroup.MapPost("/login", IdentityApiEndpoints<TUser>.Login)
+            .RequireRateLimiting(AuthEndpointsConstants.LoginPolicy);
         routeGroup.MapPost("/refresh", IdentityApiEndpoints<TUser>.Refresh);
 
         routeGroup.MapPost("/logout", IdentityApiEndpoints<TUser>.Logout)
@@ -41,38 +42,43 @@ public static class IdentityApiEndpointRouteBuilderExtensions
 
         routeGroup.MapPost("/resendConfirmationEmail", (
             ResendConfirmationEmailRequest resendRequest,
+            System.Security.Claims.ClaimsPrincipal claimsPrincipal,
             HttpContext context,
-            IServiceProvider sp) => IdentityApiEndpoints<TUser>.ResendConfirmationEmail(resendRequest, context, sp, confirmEmailEndpointName))
-            .WithSummary("Resends the confirmation email for an unverified account.")
-            .RequireAuthorization();
+            IServiceProvider sp) => IdentityApiEndpoints<TUser>.ResendConfirmationEmail(resendRequest, claimsPrincipal, context, sp, confirmEmailEndpointName))
+            .WithSummary("Resends the confirmation email for the signed-in account.")
+            .RequireAuthorization()
+            .RequireRateLimiting(AuthEndpointsConstants.AccountAbusePolicy);
 
         routeGroup.MapPost("/forgotPassword", IdentityApiEndpoints<TUser>.ForgotPassword)
-            .WithSummary("Sends a password reset email to the user.");
+            .WithSummary("Sends a password reset email to the user.")
+            .RequireRateLimiting(AuthEndpointsConstants.AccountAbusePolicy);
 
         routeGroup.MapPost("/resetPassword", IdentityApiEndpoints<TUser>.ResetPassword)
-            .WithSummary("Resets the user's password using the provided token.");
+            .WithSummary("Resets the user's password using the provided token.")
+            .RequireRateLimiting(AuthEndpointsConstants.AccountAbusePolicy);
 
         var accountGroup = routeGroup.MapGroup("/manage").RequireAuthorization();
 
         accountGroup.MapGet("/2fa", IdentityApiEndpoints<TUser>.TwoFactorStatus)
             .WithSummary("Get two-factor authentication status.");
         accountGroup.MapPost("/2fa", IdentityApiEndpoints<TUser>.ManageTwoFactor)
-            .WithSummary("Enables or disables two-factor authentication.");
+            .WithSummary("Enables or disables two-factor authentication.")
+            .RequireReauth();
         accountGroup.MapGet("/info", IdentityApiEndpoints<TUser>.ManageInfoGet);
         accountGroup.MapPost("/info", (
             System.Security.Claims.ClaimsPrincipal claimsPrincipal,
             InfoRequest infoRequest,
             HttpContext context,
             IServiceProvider sp) => IdentityApiEndpoints<TUser>.ManageInfoPost(claimsPrincipal, infoRequest, context, sp, confirmEmailEndpointName))
-            .WithSummary("Updates the current user account information.");
+            .WithSummary("Updates the current user account information.")
+            .RequireReauth();
 
         return routeGroup;
     }
 
     /// <summary>
-    /// Maps AuthEndpoints version of <c>MapIdentityApi</c>.
-    /// This method copy parts of the built-in IdentityApiEndpoints
-    /// and add more features to it.
+    /// Maps AuthEndpoints version of <c>MapIdentityApi</c> for cookie clients.
+    /// Call <see cref="ServiceCollectionExtensions.AddCookieAuthEndpoints"/> and <c>UseRateLimiter()</c>.
     /// </summary>
     public static IEndpointConventionBuilder MapCookieAuthEndpoints<TUser>(this IEndpointRouteBuilder endpoints)
         where TUser : class, new()
@@ -85,7 +91,8 @@ public static class IdentityApiEndpointRouteBuilderExtensions
             HttpContext context,
             IServiceProvider sp) => IdentityApiEndpoints<TUser>.Register(registration, context, sp, confirmEmailEndpointName))
             .WithSummary("Registers a new user account.")
-            .WithDescription("Creates a new user and sends a confirmation email if configured.");
+            .WithDescription("Creates a new user and sends a confirmation email if configured.")
+            .RequireRateLimiting(AuthEndpointsConstants.AccountAbusePolicy);
 
         routeGroup.MapPost("/login", IdentityApiEndpoints<TUser>.LoginCookie)
             .RequireRateLimiting(AuthEndpointsConstants.LoginPolicy);
@@ -105,17 +112,21 @@ public static class IdentityApiEndpointRouteBuilderExtensions
 
         routeGroup.MapPost("/resendConfirmationEmail", (
             ResendConfirmationEmailRequest resendRequest,
+            System.Security.Claims.ClaimsPrincipal claimsPrincipal,
             HttpContext context,
-            IServiceProvider sp) => IdentityApiEndpoints<TUser>.ResendConfirmationEmail(resendRequest, context, sp, confirmEmailEndpointName))
+            IServiceProvider sp) => IdentityApiEndpoints<TUser>.ResendConfirmationEmail(resendRequest, claimsPrincipal, context, sp, confirmEmailEndpointName))
             .RequireAuthorization()
             .RequireAntiforgery()
-            .WithSummary("Resends the confirmation email for an unverified account.");
+            .RequireRateLimiting(AuthEndpointsConstants.AccountAbusePolicy)
+            .WithSummary("Resends the confirmation email for the signed-in account.");
 
         routeGroup.MapPost("/forgotPassword", IdentityApiEndpoints<TUser>.ForgotPassword)
-            .WithSummary("Sends a password reset email to the user.");
+            .WithSummary("Sends a password reset email to the user.")
+            .RequireRateLimiting(AuthEndpointsConstants.AccountAbusePolicy);
 
         routeGroup.MapPost("/resetPassword", IdentityApiEndpoints<TUser>.ResetPassword)
-            .WithSummary("Resets the user's password using the provided token.");
+            .WithSummary("Resets the user's password using the provided token.")
+            .RequireRateLimiting(AuthEndpointsConstants.AccountAbusePolicy);
 
         var accountGroup = routeGroup.MapGroup("/manage").RequireAuthorization();
 
@@ -132,7 +143,8 @@ public static class IdentityApiEndpointRouteBuilderExtensions
             HttpContext context,
             IServiceProvider sp) => IdentityApiEndpoints<TUser>.ManageInfoPost(claimsPrincipal, infoRequest, context, sp, confirmEmailEndpointName))
             .WithSummary("Updates the current user account information.")
-            .RequireAntiforgery();
+            .RequireAntiforgery()
+            .RequireReauth();
 
         return routeGroup;
     }

--- a/src/AuthEndpoints/Identity/IdentityApiEndpoints.cs
+++ b/src/AuthEndpoints/Identity/IdentityApiEndpoints.cs
@@ -54,6 +54,13 @@ public class IdentityApiEndpoints<TUser>
 
         if (!result.Succeeded)
         {
+            // Avoid email enumeration: duplicate accounts look like a successful registration.
+            if (result.Errors.Any(e =>
+                    e.Code is "DuplicateUserName" or "DuplicateEmail"))
+            {
+                return TypedResults.Ok();
+            }
+
             return CreateValidationProblem(result);
         }
 
@@ -86,7 +93,7 @@ public class IdentityApiEndpoints<TUser>
 
         if (!result.Succeeded)
         {
-            return TypedResults.Problem(result.ToString(), statusCode: StatusCodes.Status401Unauthorized);
+            return CreateLoginFailureResult(result);
         }
 
         // The signInManager already produced the needed response in the form of a cookie or bearer token.
@@ -117,7 +124,7 @@ public class IdentityApiEndpoints<TUser>
 
         if (!result.Succeeded)
         {
-            return TypedResults.Problem(result.ToString(), statusCode: StatusCodes.Status401Unauthorized);
+            return CreateLoginFailureResult(result);
         }
 
         // The signInManager already produced the needed response in the form of a cookie or bearer token.
@@ -226,17 +233,26 @@ public class IdentityApiEndpoints<TUser>
 
     public static async Task<Ok> ResendConfirmationEmail(
         [FromBody] ResendConfirmationEmailRequest resendRequest,
+        ClaimsPrincipal claimsPrincipal,
         HttpContext context,
         [FromServices] IServiceProvider sp,
         string confirmEmailEndpointName)
     {
+        // Ignore the request body email — only resend for the signed-in user.
+        _ = resendRequest;
         var userManager = sp.GetRequiredService<UserManager<TUser>>();
-        if (await userManager.FindByEmailAsync(resendRequest.Email) is not { } user)
+        if (await userManager.GetUserAsync(claimsPrincipal) is not { } user)
         {
             return TypedResults.Ok();
         }
 
-        await SendConfirmationEmailAsync(user, userManager, context, resendRequest.Email, confirmEmailEndpointName);
+        var email = await userManager.GetEmailAsync(user);
+        if (string.IsNullOrEmpty(email))
+        {
+            return TypedResults.Ok();
+        }
+
+        await SendConfirmationEmailAsync(user, userManager, context, email, confirmEmailEndpointName);
         return TypedResults.Ok();
     }
 
@@ -359,7 +375,8 @@ public class IdentityApiEndpoints<TUser>
         }
 
         var key = await userManager.GetAuthenticatorKeyAsync(user);
-        if (string.IsNullOrEmpty(key))
+        var keyWasMissing = string.IsNullOrEmpty(key);
+        if (keyWasMissing)
         {
             await userManager.ResetAuthenticatorKeyAsync(user);
             key = await userManager.GetAuthenticatorKeyAsync(user);
@@ -370,9 +387,12 @@ public class IdentityApiEndpoints<TUser>
             }
         }
 
+        // Only expose the shared key when it was just (re)generated or 2FA is being enabled.
+        var exposeSharedKey = tfaRequest.ResetSharedKey || keyWasMissing || tfaRequest.Enable == true;
+
         return TypedResults.Ok(new TwoFactorResponse
         {
-            SharedKey = key,
+            SharedKey = exposeSharedKey ? key! : string.Empty,
             RecoveryCodes = recoveryCodes,
             RecoveryCodesLeft = recoveryCodes?.Length ?? await userManager.CountRecoveryCodesAsync(user),
             IsTwoFactorEnabled = await userManager.GetTwoFactorEnabledAsync(user),
@@ -477,6 +497,22 @@ public class IdentityApiEndpoints<TUser>
             ?? throw new NotSupportedException($"Could not find endpoint named '{confirmEmailEndpointName}'.");
 
         await emailSender.SendConfirmationLinkAsync(user, email, HtmlEncoder.Default.Encode(confirmEmailUrl));
+    }
+
+    private static ProblemHttpResult CreateLoginFailureResult(Microsoft.AspNetCore.Identity.SignInResult result)
+    {
+        if (result.RequiresTwoFactor)
+        {
+            return TypedResults.Problem(
+                title: "RequiresTwoFactor",
+                detail: "Two-factor authentication is required.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        return TypedResults.Problem(
+            title: "Unauthorized",
+            detail: "Invalid credentials.",
+            statusCode: StatusCodes.Status401Unauthorized);
     }
 
     private static ValidationProblem CreateValidationProblem(string errorCode, string errorDescription) =>

--- a/src/AuthEndpoints/Identity/ServiceCollectionExtensions.cs
+++ b/src/AuthEndpoints/Identity/ServiceCollectionExtensions.cs
@@ -1,22 +1,45 @@
 ﻿using System.Threading.RateLimiting;
 using AuthEndpoints.ReAuth;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AuthEndpoints.Identity;
 
 internal sealed class LoginRateLimitMarker;
+internal sealed class AccountAbuseRateLimitMarker;
+internal sealed class ConfirmIdentityRateLimitMarker;
 
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the ReAuth cookie scheme and login rate limiting used by cookie Identity endpoints.
+    /// Registers the ReAuth schemes and rate-limit policies used by cookie Identity endpoints.
+    /// Hosts must also call <c>UseRateLimiter()</c> in the pipeline for policies to take effect.
     /// For passkeys, also call <c>AddPasskeyEndpoints</c> (or call only that if you need both).
     /// </summary>
     public static IServiceCollection AddCookieAuthEndpoints(this IServiceCollection services)
     {
         services.AddReAuthScheme();
+        services.AddIdentityEndpointRateLimiting();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the ReAuth schemes and rate-limit policies used by bearer Identity endpoints.
+    /// Hosts must also call <c>UseRateLimiter()</c> in the pipeline for policies to take effect.
+    /// </summary>
+    public static IServiceCollection AddBearerAuthEndpoints(this IServiceCollection services)
+    {
+        services.AddReAuthScheme();
+        services.AddIdentityEndpointRateLimiting();
+        return services;
+    }
+
+    internal static IServiceCollection AddIdentityEndpointRateLimiting(this IServiceCollection services)
+    {
         services.AddLoginRateLimiting();
+        services.AddAccountAbuseRateLimiting();
+        services.AddConfirmIdentityRateLimiting();
         return services;
     }
 
@@ -44,6 +67,66 @@ public static class ServiceCollectionExtensions
                     AutoReplenishment = true
                 });
             });
+
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+        });
+
+        return services;
+    }
+
+    internal static IServiceCollection AddAccountAbuseRateLimiting(this IServiceCollection services)
+    {
+        if (services.Any(d => d.ServiceType == typeof(AccountAbuseRateLimitMarker)))
+        {
+            return services;
+        }
+
+        services.AddSingleton<AccountAbuseRateLimitMarker>();
+
+        services.AddRateLimiter(options =>
+        {
+            options.AddPolicy(AuthEndpointsConstants.AccountAbusePolicy, context =>
+            {
+                var key = context.Connection.RemoteIpAddress?.ToString() ?? "anon";
+
+                return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 10,
+                    Window = TimeSpan.FromMinutes(1),
+                    QueueLimit = 0
+                });
+            });
+
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+        });
+
+        return services;
+    }
+
+    internal static IServiceCollection AddConfirmIdentityRateLimiting(this IServiceCollection services)
+    {
+        if (services.Any(d => d.ServiceType == typeof(ConfirmIdentityRateLimitMarker)))
+        {
+            return services;
+        }
+
+        services.AddSingleton<ConfirmIdentityRateLimitMarker>();
+
+        services.AddRateLimiter(options =>
+        {
+            options.AddPolicy(AuthEndpointsConstants.ConfirmIdentityPolicy, context =>
+            {
+                var key = context.Connection.RemoteIpAddress?.ToString() ?? "anon";
+
+                return RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 20,
+                    Window = TimeSpan.FromMinutes(1),
+                    QueueLimit = 0
+                });
+            });
+
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
         });
 
         return services;

--- a/src/AuthEndpoints/Passkey/PasskeyEndpoints.cs
+++ b/src/AuthEndpoints/Passkey/PasskeyEndpoints.cs
@@ -201,13 +201,7 @@ public static class PasskeyEndpoints<TUser>
             });
         }
 
-        if (await userManager.FindByEmailAsync(email) is not null)
-        {
-            return TypedResults.Problem(
-                detail: "An account with this email already exists.",
-                statusCode: StatusCodes.Status400BadRequest);
-        }
-
+        // Always return creation options (even if the email exists) to avoid account enumeration.
         var userId = UserIdHelper.CreateUserIdString(typeof(TUser));
         var optionsJson = await signInManager.MakePasskeyCreationOptionsAsync(new()
         {
@@ -256,7 +250,7 @@ public static class PasskeyEndpoints<TUser>
         if (await userManager.FindByEmailAsync(email) is not null)
         {
             return TypedResults.Problem(
-                detail: "An account with this email already exists.",
+                detail: "Unable to complete registration.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
@@ -264,7 +258,7 @@ public static class PasskeyEndpoints<TUser>
         if (!attestationResult.Succeeded)
         {
             return TypedResults.Problem(
-                detail: $"Could not add the passkey: {attestationResult.Failure.Message}",
+                detail: "Unable to complete registration.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
@@ -281,7 +275,7 @@ public static class PasskeyEndpoints<TUser>
             if (!createUserResult.Succeeded)
             {
                 return TypedResults.Problem(
-                    detail: string.Join(" ", createUserResult.Errors.Select(e => e.Description)),
+                    detail: "Unable to complete registration.",
                     statusCode: StatusCodes.Status400BadRequest);
             }
         }

--- a/src/AuthEndpoints/Passkey/ServiceCollectionExtensions.cs
+++ b/src/AuthEndpoints/Passkey/ServiceCollectionExtensions.cs
@@ -11,13 +11,14 @@ internal sealed class PasskeyRateLimitMarker;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers ReAuth, login rate limiting, and passkey rate-limit policies.
-    /// Hosts should also configure <c>IdentityPasskeyOptions</c> (ServerDomain, origins, etc.).
+    /// Registers ReAuth, Identity rate limiting, and passkey rate-limit policies.
+    /// Hosts must call <c>UseRateLimiter()</c>, serve over HTTPS, and configure
+    /// <c>IdentityPasskeyOptions</c> (<c>ServerDomain</c>, allowed origins, etc.).
     /// </summary>
     public static IServiceCollection AddPasskeyEndpoints(this IServiceCollection services)
     {
         services.AddReAuthScheme();
-        services.AddLoginRateLimiting();
+        services.AddIdentityEndpointRateLimiting();
 
         if (services.Any(d => d.ServiceType == typeof(PasskeyRateLimitMarker)))
         {

--- a/src/AuthEndpoints/ReAuth/Contracts/ConfirmIdentityResponse.cs
+++ b/src/AuthEndpoints/ReAuth/Contracts/ConfirmIdentityResponse.cs
@@ -1,0 +1,11 @@
+namespace AuthEndpoints.ReAuth;
+
+public sealed class ConfirmIdentityResponse
+{
+    /// <summary>
+    /// Short-lived step-up token for API clients. Send it as the
+    /// <c>X-AuthEndpoints-Reauth</c> header on sensitive requests.
+    /// Cookie clients also receive the <c>AuthEndpoints.ReAuth</c> cookie.
+    /// </summary>
+    public required string ReauthToken { get; init; }
+}

--- a/src/AuthEndpoints/ReAuth/ReAuthApiEndpointRouteBuilderExtensions.cs
+++ b/src/AuthEndpoints/ReAuth/ReAuthApiEndpointRouteBuilderExtensions.cs
@@ -21,17 +21,20 @@ public static class ReAuthApiEndpointRouteBuilderExtensions
         var group = endpoints.MapGroup("");
 
         var confirm = group.MapPost("/confirmIdentity", ReAuthEndpoints<TUser>.ConfirmIdentity)
-            .WithSummary("Confirm the user's identity and issue a short-lived reauthentication cookie.")
+            .WithSummary("Confirm the user's identity and issue short-lived reauthentication credentials.")
             .WithDescription("""
                 Provide exactly one proof: Password, TwoFactorCode, TwoFactorRecoveryCode, or CredentialJson (passkey assertion).
-                On success, issues a temporary AuthEndpoints.ReAuth cookie (5 minutes) for sensitive actions.
+                On success, issues a temporary AuthEndpoints.ReAuth cookie (5 minutes) and a reauthToken
+                for the X-AuthEndpoints-Reauth header on sensitive API actions.
                 """)
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .RequireRateLimiting(AuthEndpointsConstants.ConfirmIdentityPolicy);
 
         var passkeyOptions = group.MapPost("/confirmIdentity/passkeyOptions", ReAuthEndpoints<TUser>.PasskeyOptions)
             .WithSummary("Generate WebAuthn request options for reauthentication with a passkey.")
             .WithDescription("Scoped to the currently signed-in user (no username query).")
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .RequireRateLimiting(AuthEndpointsConstants.ConfirmIdentityPolicy);
 
         if (requireAntiforgery)
         {

--- a/src/AuthEndpoints/ReAuth/ReAuthBearerAuthenticationHandler.cs
+++ b/src/AuthEndpoints/ReAuth/ReAuthBearerAuthenticationHandler.cs
@@ -1,0 +1,46 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using AuthEndpoints.Identity;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AuthEndpoints.ReAuth;
+
+internal sealed class ReAuthBearerAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    private readonly ReAuthTokenService _tokenService;
+
+    public ReAuthBearerAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ReAuthTokenService tokenService)
+        : base(options, logger, encoder)
+    {
+        _tokenService = tokenService;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(AuthEndpointsConstants.ReAuthHeaderName, out var headerValues))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var token = headerValues.ToString();
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var principal = _tokenService.Unprotect(token);
+        if (principal is null)
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid or expired reauthentication token."));
+        }
+
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/AuthEndpoints/ReAuth/ReAuthEndpoints.cs
+++ b/src/AuthEndpoints/ReAuth/ReAuthEndpoints.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AuthEndpoints.ReAuth;
 
@@ -48,12 +49,13 @@ public static class ReAuthEndpoints<TUser>
         return TypedResults.Content(optionsJson, contentType: "application/json");
     }
 
-    public static async Task<Results<Ok, UnauthorizedHttpResult, BadRequest<string>, ProblemHttpResult>> ConfirmIdentity(
+    public static async Task<Results<Ok<ConfirmIdentityResponse>, UnauthorizedHttpResult, BadRequest<string>, ProblemHttpResult>> ConfirmIdentity(
         [FromBody] ConfirmIdentityRequest request,
         UserManager<TUser> userManager,
         SignInManager<TUser> signInManager,
         HttpContext context)
     {
+        var tokenService = context.RequestServices.GetRequiredService<ReAuthTokenService>();
         var user = await userManager.GetUserAsync(context.User);
         if (user is null)
         {
@@ -118,7 +120,7 @@ public static class ReAuthEndpoints<TUser>
         }
         else if (!string.IsNullOrEmpty(request.Password))
         {
-            var passwordResult = await signInManager.CheckPasswordSignInAsync(user, request.Password, lockoutOnFailure: false);
+            var passwordResult = await signInManager.CheckPasswordSignInAsync(user, request.Password, lockoutOnFailure: true);
             valid = passwordResult.Succeeded;
         }
 
@@ -145,6 +147,7 @@ public static class ReAuthEndpoints<TUser>
         var identity = new ClaimsIdentity(claims, scheme);
         await context.SignInAsync(scheme, new ClaimsPrincipal(identity), authProps);
 
-        return TypedResults.Ok();
+        var reauthToken = tokenService.CreateToken(claims);
+        return TypedResults.Ok(new ConfirmIdentityResponse { ReauthToken = reauthToken });
     }
 }

--- a/src/AuthEndpoints/ReAuth/ReAuthTokenService.cs
+++ b/src/AuthEndpoints/ReAuth/ReAuthTokenService.cs
@@ -1,0 +1,76 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace AuthEndpoints.ReAuth;
+
+internal sealed class ReAuthTokenService
+{
+    private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(5);
+    private readonly IDataProtector _protector;
+    private readonly TimeProvider _timeProvider;
+
+    public ReAuthTokenService(IDataProtectionProvider dataProtectionProvider, TimeProvider timeProvider)
+    {
+        _protector = dataProtectionProvider.CreateProtector("AuthEndpoints.ReAuth.Bearer.v1");
+        _timeProvider = timeProvider;
+    }
+
+    public string CreateToken(IEnumerable<Claim> claims)
+    {
+        var expires = _timeProvider.GetUtcNow().Add(Lifetime);
+        var payload = new ReAuthTokenPayload(
+            expires.ToUnixTimeSeconds(),
+            claims.Select(c => new ReAuthClaim(c.Type, c.Value)).ToArray());
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        return Base64UrlEncode(_protector.Protect(bytes));
+    }
+
+    public ClaimsPrincipal? Unprotect(string token)
+    {
+        try
+        {
+            var bytes = _protector.Unprotect(Base64UrlDecode(token));
+            var payload = JsonSerializer.Deserialize<ReAuthTokenPayload>(bytes);
+            if (payload is null)
+            {
+                return null;
+            }
+
+            var expires = DateTimeOffset.FromUnixTimeSeconds(payload.ExpiresUnix);
+            if (_timeProvider.GetUtcNow() >= expires)
+            {
+                return null;
+            }
+
+            var identity = new ClaimsIdentity(
+                payload.Claims.Select(c => new Claim(c.Type, c.Value)),
+                AuthEndpoints.Identity.AuthEndpointsConstants.ReAuthBearerScheme);
+
+            return new ClaimsPrincipal(identity);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string Base64UrlEncode(byte[] input) =>
+        Convert.ToBase64String(input).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var padded = input.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+
+        return Convert.FromBase64String(padded);
+    }
+
+    private sealed record ReAuthTokenPayload(long ExpiresUnix, ReAuthClaim[] Claims);
+    private sealed record ReAuthClaim(string Type, string Value);
+}

--- a/src/AuthEndpoints/ReAuth/ServiceCollectionExtensions.cs
+++ b/src/AuthEndpoints/ReAuth/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 using AuthEndpoints.Identity;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace AuthEndpoints.ReAuth;
 
@@ -10,7 +12,7 @@ internal sealed class ReAuthSchemeMarker;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the short-lived ReAuth cookie scheme and authorization policy.
+    /// Registers the short-lived ReAuth cookie scheme, bearer step-up token scheme, and authorization policy.
     /// </summary>
     public static IServiceCollection AddReAuthScheme(this IServiceCollection services)
     {
@@ -20,12 +22,18 @@ public static class ServiceCollectionExtensions
         }
 
         services.AddSingleton<ReAuthSchemeMarker>();
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddDataProtection();
+        services.TryAddSingleton<ReAuthTokenService>();
 
         services.AddAuthentication()
             .AddCookie(AuthEndpointsConstants.ReAuthScheme, options =>
             {
                 options.Cookie.Name = AuthEndpointsConstants.ReAuthScheme;
                 options.Cookie.HttpOnly = true;
+                // SameAsRequest → Secure on HTTPS (production); allows HTTP test hosts.
+                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+                options.Cookie.SameSite = SameSiteMode.Strict;
                 options.ExpireTimeSpan = TimeSpan.FromMinutes(5);
                 options.SlidingExpiration = false;
 
@@ -46,13 +54,19 @@ public static class ServiceCollectionExtensions
                     context.Response.StatusCode = StatusCodes.Status204NoContent;
                     return Task.CompletedTask;
                 };
-            });
+            })
+            .AddScheme<AuthenticationSchemeOptions, ReAuthBearerAuthenticationHandler>(
+                AuthEndpointsConstants.ReAuthBearerScheme,
+                _ => { });
 
         services.AddAuthorizationBuilder()
             .AddPolicy("ReAuthPolicy", policy =>
             {
-                policy.AddAuthenticationSchemes(AuthEndpointsConstants.ReAuthScheme);
+                policy.AddAuthenticationSchemes(
+                    AuthEndpointsConstants.ReAuthScheme,
+                    AuthEndpointsConstants.ReAuthBearerScheme);
                 policy.RequireAuthenticatedUser();
+                policy.RequireClaim("Reauth", "true");
             });
 
         return services;

--- a/tests/AuthEndpoints.Tests/AssemblyInfo.cs
+++ b/tests/AuthEndpoints.Tests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Xunit;
+
+// Identity/Passkey rate limits are IP-partitioned; parallel classes share one TestServer IP.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/AuthEndpoints.Tests/AuthEndpointsFacadeTests.cs
+++ b/tests/AuthEndpoints.Tests/AuthEndpointsFacadeTests.cs
@@ -1,0 +1,192 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace AuthEndpoints.Tests;
+
+public class AuthEndpointsFacadeTests
+{
+    [Fact]
+    public async Task Facade_RegisterAndLogin_CookieIdentityWorks()
+    {
+        await using var host = await StartFacadeHostAsync(o =>
+        {
+            o.Passkeys.ServerDomain = "localhost";
+            o.ConfigureIdentity = identity =>
+            {
+                identity.SignIn.RequireConfirmedAccount = false;
+                identity.Password.RequireDigit = false;
+                identity.Password.RequireLowercase = false;
+                identity.Password.RequireUppercase = false;
+                identity.Password.RequireNonAlphanumeric = false;
+                identity.Password.RequiredLength = 6;
+            };
+        });
+
+        var server = host.GetTestServer();
+        using var http = server.CreateClient();
+        var cookies = new CookieContainer();
+
+        var email = $"facade-{Guid.NewGuid():N}@test.local";
+        var register = await SendWithCookiesAsync(http, cookies, () =>
+            http.PostAsJsonAsync("/identity/register", new
+            {
+                email,
+                password = TestHelpers.DefaultPassword
+            }));
+        Assert.Equal(HttpStatusCode.OK, register.StatusCode);
+
+        var login = await SendWithCookiesAsync(http, cookies, () =>
+            http.PostAsJsonAsync("/identity/login", new
+            {
+                email,
+                password = TestHelpers.DefaultPassword
+            }));
+        Assert.True(
+            login.StatusCode is HttpStatusCode.OK or HttpStatusCode.NoContent,
+            $"Login failed: {(int)login.StatusCode} {await login.Content.ReadAsStringAsync()}");
+
+        using var infoRequest = new HttpRequestMessage(HttpMethod.Get, "/identity/manage/info");
+        ApplyCookies(infoRequest, cookies, http.BaseAddress!);
+        var info = await http.SendAsync(infoRequest);
+        CaptureCookies(info, cookies, http.BaseAddress!);
+        Assert.Equal(HttpStatusCode.OK, info.StatusCode);
+    }
+
+    [Fact]
+    public void Facade_Production_MissingPasskeyServerDomain_FailsValidation()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddDbContext<TestDbContext>(o =>
+            o.UseInMemoryDatabase("FacadeProdDomain_" + Guid.NewGuid().ToString("N")));
+        builder.Services.AddAuthEndpoints<TestAppUser, TestDbContext>(o =>
+        {
+            o.Passkeys.Enabled = true;
+            o.Passkeys.ServerDomain = null;
+            o.RequireEmailSenderInProduction = false;
+        });
+        builder.Services.AddTransient<IEmailSender<TestAppUser>, TestEmailSender>();
+
+        using var app = builder.Build();
+        app.UseAuthEndpoints();
+
+        var ex = Assert.ThrowsAny<Exception>(() => app.MapAuthEndpoints<TestAppUser>());
+        Assert.Contains("ServerDomain", ex.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Facade_Production_NoOpEmailSender_FailsValidation()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddDbContext<TestDbContext>(o =>
+            o.UseInMemoryDatabase("FacadeProdEmail_" + Guid.NewGuid().ToString("N")));
+        builder.Services.AddAuthEndpoints<TestAppUser, TestDbContext>(o =>
+        {
+            o.Passkeys.ServerDomain = "example.com";
+            o.RequireEmailSenderInProduction = true;
+        });
+
+        using var app = builder.Build();
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+        {
+            _ = app.Services.GetRequiredService<IOptions<AuthEndpointsOptions>>().Value;
+        });
+        Assert.Contains("IEmailSender", ex.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Facade_Options_DefaultPaths()
+    {
+        var options = new AuthEndpointsOptions();
+        Assert.Equal("/identity", options.IdentityPath);
+        Assert.Equal("/account", options.PasskeyPath);
+        Assert.True(options.RequireConfirmedAccount);
+        Assert.True(options.Passkeys.Enabled);
+        Assert.True(options.RequireEmailSenderInProduction);
+    }
+
+    private static async Task<WebApplication> StartFacadeHostAsync(Action<AuthEndpointsOptions>? configure = null)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development
+        });
+        builder.WebHost.UseTestServer();
+
+        var dbName = "FacadeHost_" + Guid.NewGuid().ToString("N");
+        builder.Services.AddDbContext<TestDbContext>(o => o.UseInMemoryDatabase(dbName));
+        builder.Services.AddAuthEndpoints<TestAppUser, TestDbContext>(o =>
+        {
+            o.Passkeys.ServerDomain = "localhost";
+            configure?.Invoke(o);
+        });
+        builder.Services.AddTransient<IEmailSender<TestAppUser>, TestEmailSender>();
+
+        var app = builder.Build();
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+            await db.Database.EnsureCreatedAsync();
+        }
+
+        app.UseAuthEndpoints();
+        app.MapAuthEndpoints<TestAppUser>();
+        await app.StartAsync();
+        return app;
+    }
+
+    private static async Task<HttpResponseMessage> SendWithCookiesAsync(
+        HttpClient http,
+        CookieContainer cookies,
+        Func<Task<HttpResponseMessage>> send)
+    {
+        ApplyDefaultCookieHeader(http, cookies);
+        var response = await send();
+        CaptureCookies(response, cookies, http.BaseAddress!);
+        ApplyDefaultCookieHeader(http, cookies);
+        return response;
+    }
+
+    private static void ApplyDefaultCookieHeader(HttpClient http, CookieContainer cookies)
+    {
+        http.DefaultRequestHeaders.Remove("Cookie");
+        var header = cookies.GetCookieHeader(http.BaseAddress!);
+        if (!string.IsNullOrEmpty(header))
+        {
+            http.DefaultRequestHeaders.TryAddWithoutValidation("Cookie", header);
+        }
+    }
+
+    private static void ApplyCookies(HttpRequestMessage request, CookieContainer cookies, Uri baseAddress)
+    {
+        var header = cookies.GetCookieHeader(baseAddress);
+        if (!string.IsNullOrEmpty(header))
+        {
+            request.Headers.TryAddWithoutValidation("Cookie", header);
+        }
+    }
+
+    private static void CaptureCookies(HttpResponseMessage response, CookieContainer cookies, Uri baseAddress)
+    {
+        if (!response.Headers.TryGetValues("Set-Cookie", out var values))
+        {
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            cookies.SetCookies(baseAddress, value);
+        }
+    }
+}

--- a/tests/AuthEndpoints.Tests/IdentityBearerEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/IdentityBearerEndpointsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Text.Json;
+using AuthEndpoints.Identity;
 
 namespace AuthEndpoints.Tests;
 
@@ -123,7 +124,31 @@ public class IdentityBearerEndpointsTests : IClassFixture<TestWebApplicationFact
     }
 
     [Fact]
-    public async Task ManageInfoPost_WithBearer_SucceedsWithoutCsrf()
+    public async Task ManageInfoPost_WithoutReauth_ReturnsUnauthorized()
+    {
+        var email = $"bearer-info-noreauth-{Guid.NewGuid():N}@test.local";
+        await TestHelpers.SeedUserAsync(_factory, email);
+        using var client = _factory.CreateClient();
+
+        var (accessToken, _) = await TestHelpers.LoginBearerAsync(
+            client,
+            email,
+            TestHelpers.DefaultPassword);
+        TestHelpers.SetBearer(client, accessToken);
+
+        var response = await client.PostAsJsonAsync("/identity/bearer/manage/info", new
+        {
+            oldPassword = TestHelpers.DefaultPassword,
+            newPassword = "BearerChanged1!"
+        });
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden,
+            $"Expected 401/403, got {(int)response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task ManageInfoPost_WithReauthHeader_SucceedsWithoutCsrf()
     {
         var email = $"bearer-info-{Guid.NewGuid():N}@test.local";
         await TestHelpers.SeedUserAsync(_factory, email);
@@ -136,6 +161,11 @@ public class IdentityBearerEndpointsTests : IClassFixture<TestWebApplicationFact
             TestHelpers.DefaultPassword);
         TestHelpers.SetBearer(client, accessToken);
 
+        var reauthToken = await TestHelpers.ConfirmIdentityBearerAsync(
+            client,
+            new { password = TestHelpers.DefaultPassword });
+        TestHelpers.SetReauthToken(client, reauthToken);
+
         var response = await client.PostAsJsonAsync("/identity/bearer/manage/info", new
         {
             oldPassword = TestHelpers.DefaultPassword,
@@ -144,7 +174,32 @@ public class IdentityBearerEndpointsTests : IClassFixture<TestWebApplicationFact
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         client.DefaultRequestHeaders.Authorization = null;
+        client.DefaultRequestHeaders.Remove(AuthEndpointsConstants.ReAuthHeaderName);
         var (newAccess, _) = await TestHelpers.LoginBearerAsync(client, email, newPassword);
         Assert.False(string.IsNullOrWhiteSpace(newAccess));
+    }
+
+    [Fact]
+    public async Task ManageTwoFactor_WithoutReauth_ReturnsUnauthorized()
+    {
+        var email = $"bearer-2fa-noreauth-{Guid.NewGuid():N}@test.local";
+        await TestHelpers.SeedUserAsync(_factory, email);
+        using var client = _factory.CreateClient();
+
+        var (accessToken, _) = await TestHelpers.LoginBearerAsync(
+            client,
+            email,
+            TestHelpers.DefaultPassword);
+        TestHelpers.SetBearer(client, accessToken);
+
+        var response = await client.PostAsJsonAsync("/identity/bearer/manage/2fa", new
+        {
+            enable = true,
+            twoFactorCode = "000000"
+        });
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden,
+            $"Expected 401/403, got {(int)response.StatusCode}");
     }
 }

--- a/tests/AuthEndpoints.Tests/IdentityCookieEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/IdentityCookieEndpointsTests.cs
@@ -45,7 +45,7 @@ public class IdentityCookieEndpointsTests : IClassFixture<TestWebApplicationFact
     }
 
     [Fact]
-    public async Task Register_DuplicateEmail_ReturnsValidationProblem()
+    public async Task Register_DuplicateEmail_ReturnsOkWithoutCreatingSecondUser()
     {
         var email = $"dup-{Guid.NewGuid():N}@test.local";
         await TestHelpers.SeedUserAsync(_factory, email);
@@ -57,7 +57,9 @@ public class IdentityCookieEndpointsTests : IClassFixture<TestWebApplicationFact
             password = TestHelpers.DefaultPassword
         });
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var user = await TestHelpers.FindUserByEmailAsync(_factory, email);
+        Assert.NotNull(user);
     }
 
     [Fact]
@@ -80,7 +82,7 @@ public class IdentityCookieEndpointsTests : IClassFixture<TestWebApplicationFact
     }
 
     [Fact]
-    public async Task Login_WrongPassword_ReturnsUnauthorized()
+    public async Task Login_WrongPassword_ReturnsGenericUnauthorized()
     {
         var email = $"login-bad-{Guid.NewGuid():N}@test.local";
         await TestHelpers.SeedUserAsync(_factory, email);
@@ -93,6 +95,9 @@ public class IdentityCookieEndpointsTests : IClassFixture<TestWebApplicationFact
         });
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Invalid credentials", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("LockedOut", body, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -111,6 +116,7 @@ public class IdentityCookieEndpointsTests : IClassFixture<TestWebApplicationFact
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("RequiresTwoFactor", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("LockedOut", body, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/AuthEndpoints.Tests/IdentityManageEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/IdentityManageEndpointsTests.cs
@@ -30,6 +30,25 @@ public class IdentityManageEndpointsTests : IClassFixture<TestWebApplicationFact
     }
 
     [Fact]
+    public async Task ManageInfoPost_WithoutReAuth_IsUnauthorized()
+    {
+        var email = $"pwd-noreauth-{Guid.NewGuid():N}@test.local";
+        await TestHelpers.SeedUserAsync(_factory, email);
+        using var client = TestHelpers.CreateClientWithCookies(_factory);
+        await TestHelpers.LoginCookieAsync(client, email, TestHelpers.DefaultPassword);
+
+        var response = await TestHelpers.PostWithCsrfAsync(client, "/identity/manage/info", new
+        {
+            oldPassword = TestHelpers.DefaultPassword,
+            newPassword = "ChangedPass1!"
+        });
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden,
+            $"Expected 401/403 without ReAuth, got {(int)response.StatusCode}");
+    }
+
+    [Fact]
     public async Task ManageInfoPost_ChangePassword_Succeeds()
     {
         var email = $"pwd-{Guid.NewGuid():N}@test.local";
@@ -37,6 +56,7 @@ public class IdentityManageEndpointsTests : IClassFixture<TestWebApplicationFact
         const string newPassword = "ChangedPass1!";
         using var client = TestHelpers.CreateClientWithCookies(_factory);
         await TestHelpers.LoginCookieAsync(client, email, TestHelpers.DefaultPassword);
+        await TestHelpers.ConfirmIdentityAsync(client, new { password = TestHelpers.DefaultPassword });
 
         var response = await TestHelpers.PostWithCsrfAsync(client, "/identity/manage/info", new
         {
@@ -56,6 +76,7 @@ public class IdentityManageEndpointsTests : IClassFixture<TestWebApplicationFact
         await TestHelpers.SeedUserAsync(_factory, email);
         using var client = TestHelpers.CreateClientWithCookies(_factory);
         await TestHelpers.LoginCookieAsync(client, email, TestHelpers.DefaultPassword);
+        await TestHelpers.ConfirmIdentityAsync(client, new { password = TestHelpers.DefaultPassword });
 
         var response = await TestHelpers.PostWithCsrfAsync(client, "/identity/manage/info", new
         {
@@ -110,14 +131,9 @@ public class IdentityManageEndpointsTests : IClassFixture<TestWebApplicationFact
         var user = await TestHelpers.SeedUserAsync(_factory, email);
         using var client = TestHelpers.CreateClientWithCookies(_factory);
         await TestHelpers.LoginCookieAsync(client, email, TestHelpers.DefaultPassword);
+        await TestHelpers.ConfirmIdentityAsync(client, new { password = TestHelpers.DefaultPassword });
 
-        var confirm = await TestHelpers.PostWithCsrfAsync(client, "/identity/confirmIdentity", new
-        {
-            password = TestHelpers.DefaultPassword
-        });
-        Assert.Equal(HttpStatusCode.OK, confirm.StatusCode);
-
-        // Probe manage/2fa to ensure a shared key exists (handler mints one when missing).
+        // Probe manage/2fa to mint a shared key when missing (exposed because key was just created).
         var probe = await TestHelpers.PostWithCsrfAsync(client, "/identity/manage/2fa", new { });
         Assert.Equal(HttpStatusCode.OK, probe.StatusCode);
 
@@ -125,12 +141,7 @@ public class IdentityManageEndpointsTests : IClassFixture<TestWebApplicationFact
         var sharedKey = TestHelpers.TryGetString(probeDoc.RootElement, "sharedKey", "SharedKey");
         Assert.False(string.IsNullOrWhiteSpace(sharedKey));
 
-        // Re-confirm in case the previous manage call consumed anything unexpected; ReAuth cookie is 5 minutes.
-        var confirmAgain = await TestHelpers.PostWithCsrfAsync(client, "/identity/confirmIdentity", new
-        {
-            password = TestHelpers.DefaultPassword
-        });
-        Assert.Equal(HttpStatusCode.OK, confirmAgain.StatusCode);
+        await TestHelpers.ConfirmIdentityAsync(client, new { password = TestHelpers.DefaultPassword });
 
         var code = TotpHelper.GenerateCode(sharedKey!);
         var enable = await TestHelpers.PostWithCsrfAsync(client, "/identity/manage/2fa", new

--- a/tests/AuthEndpoints.Tests/Infrastructure/TestEmailSender.cs
+++ b/tests/AuthEndpoints.Tests/Infrastructure/TestEmailSender.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace AuthEndpoints.Tests;
+
+internal sealed class TestEmailSender : IEmailSender<TestAppUser>
+{
+    public List<(string Email, string Subject)> Sent { get; } = [];
+
+    public Task SendConfirmationLinkAsync(TestAppUser user, string email, string confirmationLink)
+    {
+        Sent.Add((email, "confirm"));
+        return Task.CompletedTask;
+    }
+
+    public Task SendPasswordResetCodeAsync(TestAppUser user, string email, string resetCode)
+    {
+        Sent.Add((email, "reset"));
+        return Task.CompletedTask;
+    }
+
+    public Task SendPasswordResetLinkAsync(TestAppUser user, string email, string resetLink)
+    {
+        Sent.Add((email, "reset-link"));
+        return Task.CompletedTask;
+    }
+}

--- a/tests/AuthEndpoints.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/AuthEndpoints.Tests/Infrastructure/TestHelpers.cs
@@ -1,10 +1,13 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using AuthEndpoints.Identity;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AuthEndpoints.Tests;
 
@@ -83,7 +86,8 @@ internal static class TestHelpers
     public static async Task<HttpResponseMessage> PostWithCsrfAsync(
         HttpClient client,
         string url,
-        object? body)
+        object? body,
+        string? reauthToken = null)
     {
         var csrf = await GetCsrfTokenAsync(client);
         using var request = new HttpRequestMessage(HttpMethod.Post, url)
@@ -91,7 +95,50 @@ internal static class TestHelpers
             Content = body is null ? null : JsonContent.Create(body)
         };
         request.Headers.Add("RequestVerificationToken", csrf);
+        if (!string.IsNullOrEmpty(reauthToken))
+        {
+            request.Headers.Add(AuthEndpointsConstants.ReAuthHeaderName, reauthToken);
+        }
+
         return await client.SendAsync(request);
+    }
+
+    public static async Task<string> ConfirmIdentityAsync(
+        HttpClient client,
+        object proof,
+        bool useCsrf = true)
+    {
+        HttpResponseMessage response;
+        if (useCsrf)
+        {
+            response = await PostWithCsrfAsync(client, "/identity/confirmIdentity", proof);
+        }
+        else
+        {
+            response = await client.PostAsJsonAsync("/identity/confirmIdentity", proof);
+        }
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var token = TryGetString(doc.RootElement, "reauthToken", "ReauthToken");
+        Assert.False(string.IsNullOrWhiteSpace(token), "Expected reauthToken in ConfirmIdentity response.");
+        return token!;
+    }
+
+    public static async Task<string> ConfirmIdentityBearerAsync(HttpClient client, object proof)
+    {
+        var response = await client.PostAsJsonAsync("/identity/bearer/confirmIdentity", proof);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var token = TryGetString(doc.RootElement, "reauthToken", "ReauthToken");
+        Assert.False(string.IsNullOrWhiteSpace(token), "Expected reauthToken in ConfirmIdentity response.");
+        return token!;
+    }
+
+    public static void SetReauthToken(HttpClient client, string reauthToken)
+    {
+        client.DefaultRequestHeaders.Remove(AuthEndpointsConstants.ReAuthHeaderName);
+        client.DefaultRequestHeaders.Add(AuthEndpointsConstants.ReAuthHeaderName, reauthToken);
     }
 
     public static async Task<(string AccessToken, string RefreshToken)> LoginBearerAsync(

--- a/tests/AuthEndpoints.Tests/PasskeyEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/PasskeyEndpointsTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Net;
+using System.Text.Json;
+
+namespace AuthEndpoints.Tests;
+
+public class PasskeyEndpointsTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public PasskeyEndpointsTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task RegisterOptions_ExistingEmail_ReturnsOptionsJson()
+    {
+        var email = $"passkey-enum-{Guid.NewGuid():N}@test.local";
+        await TestHelpers.SeedUserAsync(_factory, email);
+        using var client = TestHelpers.CreateClientWithCookies(_factory);
+
+        var csrf = await TestHelpers.GetCsrfTokenAsync(client);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/account/passkeys/register/options")
+        {
+            Content = JsonContent.Create(new { email })
+        };
+        request.Headers.Add("RequestVerificationToken", csrf);
+
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("already exists", body, StringComparison.OrdinalIgnoreCase);
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task Register_ExistingEmail_ReturnsGenericBadRequest()
+    {
+        var email = $"passkey-reg-{Guid.NewGuid():N}@test.local";
+        await TestHelpers.SeedUserAsync(_factory, email);
+        using var client = TestHelpers.CreateClientWithCookies(_factory);
+
+        var csrf = await TestHelpers.GetCsrfTokenAsync(client);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/account/passkeys/register")
+        {
+            Content = JsonContent.Create(new
+            {
+                email,
+                credentialJson = "{}"
+            })
+        };
+        request.Headers.Add("RequestVerificationToken", csrf);
+
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Unable to complete registration", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("already exists", body, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/AuthEndpoints.Tests/ReAuthEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/ReAuthEndpointsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
 
 namespace AuthEndpoints.Tests;
 
@@ -115,5 +116,42 @@ public class ReAuthEndpointsTests : IClassFixture<TestWebApplicationFactory>
 
         var reauthResponse = await client.GetAsync("/test/reauth");
         Assert.Equal(HttpStatusCode.OK, reauthResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task ConfirmIdentity_WrongPassword_IncrementsAccessFailedCount()
+    {
+        var email = $"reauth-lockout-{Guid.NewGuid():N}@test.local";
+        var user = await TestHelpers.SeedUserAsync(_factory, email);
+
+        using var client = TestHelpers.CreateClientWithCookies(_factory);
+        await TestHelpers.LoginCookieAsync(client, email, TestHelpers.DefaultPassword);
+
+        var confirmResponse = await TestHelpers.PostWithCsrfAsync(
+            client,
+            "/identity/confirmIdentity",
+            new { password = "WrongPass1!" });
+        Assert.Equal(HttpStatusCode.Unauthorized, confirmResponse.StatusCode);
+
+        using var scope = _factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<TestAppUser>>();
+        var tracked = await userManager.FindByIdAsync(user.Id);
+        Assert.NotNull(tracked);
+        Assert.True(await userManager.GetAccessFailedCountAsync(tracked) > 0);
+    }
+
+    [Fact]
+    public async Task ConfirmIdentity_ReturnsReauthToken()
+    {
+        var email = $"reauth-token-{Guid.NewGuid():N}@test.local";
+        await TestHelpers.SeedUserAsync(_factory, email);
+
+        using var client = TestHelpers.CreateClientWithCookies(_factory);
+        await TestHelpers.LoginCookieAsync(client, email, TestHelpers.DefaultPassword);
+
+        var token = await TestHelpers.ConfirmIdentityAsync(
+            client,
+            new { password = TestHelpers.DefaultPassword });
+        Assert.False(string.IsNullOrWhiteSpace(token));
     }
 }

--- a/tests/Demo/Infrastructure/ConsoleEmailSender.cs
+++ b/tests/Demo/Infrastructure/ConsoleEmailSender.cs
@@ -1,0 +1,26 @@
+using Demo.Models;
+using Microsoft.AspNetCore.Identity;
+
+namespace Demo.Infrastructure;
+
+/// <summary>Development-only email sender that writes to the console.</summary>
+internal sealed class ConsoleEmailSender : IEmailSender<AppUser>
+{
+    public Task SendConfirmationLinkAsync(AppUser user, string email, string confirmationLink)
+    {
+        Console.WriteLine($"[Email] Confirmation for {email}: {confirmationLink}");
+        return Task.CompletedTask;
+    }
+
+    public Task SendPasswordResetCodeAsync(AppUser user, string email, string resetCode)
+    {
+        Console.WriteLine($"[Email] Password reset code for {email}: {resetCode}");
+        return Task.CompletedTask;
+    }
+
+    public Task SendPasswordResetLinkAsync(AppUser user, string email, string resetLink)
+    {
+        Console.WriteLine($"[Email] Password reset link for {email}: {resetLink}");
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Demo/Program.cs
+++ b/tests/Demo/Program.cs
@@ -1,10 +1,11 @@
 using Demo.Data;
+using Demo.Infrastructure;
 using Demo.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using AuthEndpoints;
 using AuthEndpoints.Jwt;
 using AuthEndpoints.Identity;
-using AuthEndpoints.Passkey;
 using AuthEndpoints.ReAuth;
 using Scalar.AspNetCore;
 
@@ -12,8 +13,6 @@ var builder = WebApplication.CreateBuilder(args);
 
 DotNetEnv.Env.Load();
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 builder.Services.AddEndpointsApiExplorer();
 
@@ -21,40 +20,28 @@ builder.Services.AddDbContext<AppDbContext>(o =>
 {
     o.UseSqlite(Environment.GetEnvironmentVariable("DB_CONNECTION_STRING")!);
 });
-builder.Services
-    .AddIdentityApiEndpoints<AppUser>(o =>
-    {
-        o.SignIn.RequireConfirmedAccount = true;
-        o.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
-    })
-    .AddRoles<AppRole>()
-    .AddEntityFrameworkStores<AppDbContext>()
-    .AddDefaultTokenProviders();
 
-builder.Services.Configure<IdentityPasskeyOptions>(options =>
-{
-    // Use the host that serves the app in development (adjust for production).
-    options.ServerDomain = "localhost";
-});
+builder.Services
+    .AddAuthEndpoints<AppUser, AppDbContext>(o =>
+    {
+        o.IdentityPath = "/auth/cookie";
+        o.PasskeyPath = "/auth/passkey";
+        o.Passkeys.ServerDomain = "localhost";
+        o.RequireConfirmedAccount = true;
+    })
+    .AddRoles<AppRole>();
+
+builder.Services.AddTransient<IEmailSender<AppUser>, ConsoleEmailSender>();
 
 builder.Services.AddJwtEndpoints<AppUser, AppDbContext>(options =>
 {
-    // Demo-only stable key. Set a secret from configuration/environment in real apps.
     options.SigningOptions.SymmetricKey =
         Environment.GetEnvironmentVariable("JWT_SYMMETRIC_KEY")
         ?? "DemoOnly_ChangeMe_AuthEndpoints_Jwt_SigningKey_32+";
 });
 
-builder.Services.AddAuthorization();
-
-builder.Services.AddAntiforgery();
-
-builder.Services.AddCookieAuthEndpoints();
-builder.Services.AddPasskeyEndpoints();
-
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
@@ -65,19 +52,13 @@ else
     app.UseHttpsRedirection();
 }
 
-app.UseAuthentication();
-app.UseAuthorization();
-app.UseRateLimiter();
-
-app.UseAntiforgery();
+app.UseAuthEndpoints();
 app.UseMiddleware<AntiforgeryEnforcementMiddleware>();
 
+app.MapAuthEndpoints<AppUser>();
 app.MapGroup("/auth/jwt").MapJwtAuthEndpoints<AppUser>().WithTags("Jwt");
-app.MapGroup("/auth/cookie").MapCookieAuthEndpoints<AppUser>().WithTags("Identity: Cookie scheme");
-app.MapGroup("/auth/passkey").MapPasskeyEndpoints<AppUser>().WithTags("Passkeys");
 
 app.MapPost("/test/csrf", () => Results.Ok()).EnableAntiforgery();
-
 app.MapGet("/test/reauth", () => Results.Ok()).RequireReauth();
 
 app.MapGet("createDefaultUser", async (UserManager<AppUser> userManager) =>


### PR DESCRIPTION
## Summary
- Add safe-by-default `AddAuthEndpoints` / `UseAuthEndpoints` / `MapAuthEndpoints` (cookie Identity + passkeys) with Production fail-fast for email sender and passkey `ServerDomain`
- Harden Identity/Passkey/ReAuth: abuse rate limits, anti-enumeration, login response hygiene, ReAuth lockout, bearer step-up via `X-AuthEndpoints-Reauth`
- Expand integration tests for Identity, ReAuth, Passkey, and the facade; bump package to `3.0.0-rc.1`