### PR TITLE
Cut AuthEndpoints 3.0.0 stable

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -14,7 +14,7 @@ This repo publishes two NuGet packages with **independent versions**:
 
 | Package | Typical GitHub tag | Notes |
 | --- | --- | --- |
-| `AuthEndpoints` | `v3.0.0-rc.x` | Core library |
+| `AuthEndpoints` | `v3.0.0` | Core library |
 | `AuthEndpoints.External.OAuth` | `external-oauth-v3.0.0-preview.x` | Preview OAuth module |
 
 - Set `<Version>` only on the package(s) you intend to ship. The publish workflow packs the solution and uses `--skip-duplicate`.

--- a/Documentation/content/1.getting-started/2.installation.md
+++ b/Documentation/content/1.getting-started/2.installation.md
@@ -7,13 +7,13 @@ navigation:
 
 ## NuGet package
 
-[![nuget](https://img.shields.io/nuget/vpre/AuthEndpoints?label=version&logo=NuGet&style=flat-square)](https://www.nuget.org/packages/AuthEndpoints/)
+[![nuget](https://img.shields.io/nuget/v/AuthEndpoints?label=version&logo=NuGet&style=flat-square)](https://www.nuget.org/packages/AuthEndpoints/)
 
 ```bash
-dotnet add package AuthEndpoints --prerelease
+dotnet add package AuthEndpoints
 ```
 
-Use `--prerelease` while AuthEndpoints publishes RC/preview builds; a bare `dotnet add package` installs the latest **stable** only. Exact versions are listed on [NuGet](https://www.nuget.org/packages/AuthEndpoints/) and in the [changelog](/changelog).
+Exact versions are listed on [NuGet](https://www.nuget.org/packages/AuthEndpoints/) and in the [changelog](/changelog).
 
 ## Requirements
 

--- a/Documentation/content/3.modules/7.external-oauth.md
+++ b/Documentation/content/3.modules/7.external-oauth.md
@@ -14,13 +14,13 @@ External OAuth (GitHub, Google) ships as a **separate NuGet package**: `AuthEndp
 ## Install
 
 ```bash
-dotnet add package AuthEndpoints --prerelease
+dotnet add package AuthEndpoints
 dotnet add package AuthEndpoints.External.OAuth --prerelease
 ```
 
-Use `--prerelease` while these packages publish RC/preview builds. Requires ASP.NET Core Identity (`UserManager` / `SignInManager`) already configured — typically via [AddAuthEndpoints](/getting-started/quick-start). It does **not** call Identity management HTTP APIs; those remain optional alongside External.
+Use `--prerelease` for the OAuth preview package. Core AuthEndpoints 3.0 is stable. Requires ASP.NET Core Identity (`UserManager` / `SignInManager`) already configured — typically via [AddAuthEndpoints](/getting-started/quick-start). It does **not** call Identity management HTTP APIs; those remain optional alongside External.
 
-Current External.OAuth previews need a compatible AuthEndpoints **3.0 RC or later** — see the [changelog](/changelog) for the minimum core version for each OAuth release.
+Current External.OAuth previews need AuthEndpoints **3.0.0 or later** — see the [changelog](/changelog) for the minimum core version for each OAuth release.
 
 Hosts must call `UseRateLimiter()` (included in `UseAuthEndpoints`). `AddExternalAuthEndpoints` registers the login rate-limit policy.
 

--- a/Documentation/content/versions/external-oauth-v3.0.0-preview.3.md
+++ b/Documentation/content/versions/external-oauth-v3.0.0-preview.3.md
@@ -1,0 +1,18 @@
+---
+title: AuthEndpoints.External.OAuth 3.0.0-preview.3
+description: Retarget the preview OAuth package to depend on stable AuthEndpoints 3.0.0.
+date: 2026-08-27
+badge: Preview
+tag: external-oauth-v3.0.0-preview.3
+---
+
+### AuthEndpoints.External.OAuth
+
+- Bump to `3.0.0-preview.3` so the packed nupkg depends on **AuthEndpoints 3.0.0** (published `3.0.0-preview.2` still depends on `3.0.0-rc.2`)
+- No OAuth feature changes; the package remains preview and is not part of the core 3.0 GA
+
+### Links
+
+- [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/external-oauth-v3.0.0-preview.3)
+- [Compare](https://github.com/madeyoga/AuthEndpoints/compare/external-oauth-v3.0.0-preview.2...external-oauth-v3.0.0-preview.3)
+- [External OAuth docs](https://madeyoga.github.io/AuthEndpoints/modules/external-oauth)

--- a/Documentation/content/versions/v3.0.0-rc.3.md
+++ b/Documentation/content/versions/v3.0.0-rc.3.md
@@ -2,7 +2,7 @@
 title: v3.0.0-rc.3
 description: Roles-aware AddAuthEndpoints overload and public login rate-limiting API.
 date: 2026-07-30
-badge: Latest
+badge: RC
 tag: v3.0.0-rc.3
 ---
 

--- a/Documentation/content/versions/v3.0.0-rc.4.md
+++ b/Documentation/content/versions/v3.0.0-rc.4.md
@@ -2,6 +2,7 @@
 title: v3.0.0-rc.4
 description: Pluggable passkey sign-in completer with Simple JWT support.
 date: 2026-08-02
+badge: RC
 tag: v3.0.0-rc.4
 ---
 
@@ -14,7 +15,7 @@ tag: v3.0.0-rc.4
 
 ### Packages
 
-- **AuthEndpoints** `3.0.0-rc.4` (pending publish)
+- **AuthEndpoints** `3.0.0-rc.4`
 - **AuthEndpoints.External.OAuth** (unchanged)
 
 ### Links

--- a/Documentation/content/versions/v3.0.0.md
+++ b/Documentation/content/versions/v3.0.0.md
@@ -1,0 +1,30 @@
+---
+title: v3.0.0
+description: First stable 3.0 release — opinionated facade, cookie / bearer / JWT, passkeys, 2FA, and ReAuth on .NET 10.
+date: 2026-08-27
+badge: Latest
+tag: v3.0.0
+---
+
+### AuthEndpoints
+
+3.0 is the first stable release of the rewritten Identity auth stack. Last feature work was rc.4 (pluggable passkey sign-in); this cut is version and docs only.
+
+- Opinionated facade: `AddAuthEndpoints` / `UseAuthEndpoints` / `MapAuthEndpoints` (cookie Identity + passkeys by default; JWT opt-in)
+- Sign-in stacks you choose: cookie sessions, Identity bearer tokens, or Simple JWT (hashed refresh tokens, production issuer/audience/key validation)
+- Passkeys (WebAuthn) for passwordless register and login, including pluggable `IPasskeySignInCompleter<TUser>` (`IdentityPasskeySignInCompleter` and `JwtPasskeySignInCompleter`)
+- Account lifecycle: register, confirm email, forgot/reset password, manage info and 2FA
+- Step-up ReAuth for sensitive manage and passkey mutations
+- Roles-aware `AddAuthEndpoints<TUser, TRole, TContext>` so Identity `IRoleStore` registers correctly
+- .NET 10 (`net10.0`)
+
+### Packages
+
+- **AuthEndpoints** `3.0.0`
+- **AuthEndpoints.External.OAuth** remains a separate preview package (`3.0.0-preview.3`, retargeted at this core)
+
+### Links
+
+- [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/v3.0.0)
+- [Compare](https://github.com/madeyoga/AuthEndpoints/compare/v3.0.0-rc.4...v3.0.0)
+- [Installation](/getting-started/installation)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AuthEndpoints
 
-[![nuget](https://img.shields.io/nuget/vpre/AuthEndpoints?label=version&logo=NuGet&style=flat-square)](https://www.nuget.org/packages/AuthEndpoints/)
+[![nuget](https://img.shields.io/nuget/v/AuthEndpoints?label=version&logo=NuGet&style=flat-square)](https://www.nuget.org/packages/AuthEndpoints/)
 [![issues](https://img.shields.io/github/issues/madeyoga/AuthEndpoints?color=blue&logo=github&style=flat-square)](https://github.com/madeyoga/AuthEndpoints/issues)
 [![downloads](https://img.shields.io/nuget/dt/AuthEndpoints?color=blue&style=flat-square&logo=nuget)](https://www.nuget.org/packages/AuthEndpoints/)
 ![workflow](https://github.com/madeyoga/AuthEndpoints/actions/workflows/dotnet.yml/badge.svg)
@@ -21,7 +21,7 @@ AuthEndpoints is an ASP.NET Core library of ready-made auth API endpoints on top
 Requires .NET 10, ASP.NET Core Identity, and EF Core.
 
 ```bash
-dotnet add package AuthEndpoints --prerelease
+dotnet add package AuthEndpoints
 ```
 
 ```cs

--- a/src/AuthEndpoints.External.OAuth/AuthEndpoints.External.OAuth.csproj
+++ b/src/AuthEndpoints.External.OAuth/AuthEndpoints.External.OAuth.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>AuthEndpoints.External.OAuth</PackageId>
     <Description>Minimal API endpoints for external OAuth authentication (GitHub, Google) with ASP.NET Core Identity</Description>
-    <Version>3.0.0-preview.2</Version>
+    <Version>3.0.0-preview.3</Version>
     <Authors>madeyoga</Authors>
     <Company>madeyoga</Company>
     <PackageProjectUrl>https://github.com/madeyoga/AuthEndpoints</PackageProjectUrl>

--- a/src/AuthEndpoints.External.OAuth/README.md
+++ b/src/AuthEndpoints.External.OAuth/README.md
@@ -16,7 +16,7 @@ This package references **both** GitHub and Google OAuth handler packages. Split
 dotnet add package AuthEndpoints.External.OAuth --prerelease
 ```
 
-Use `--prerelease` while this package publishes preview builds. Requires a compatible [AuthEndpoints](https://www.nuget.org/packages/AuthEndpoints/) **3.0 RC or later** (Identity host) — see the [changelog](https://madeyoga.github.io/AuthEndpoints/changelog) for minimum core versions. Does not use Identity management HTTP APIs.
+Use `--prerelease` while this package publishes preview builds. Requires [AuthEndpoints](https://www.nuget.org/packages/AuthEndpoints/) **3.0.0 or later** (Identity host) — see the [changelog](https://madeyoga.github.io/AuthEndpoints/changelog) for minimum core versions. Does not use Identity management HTTP APIs.
 
 ## Usage
 

--- a/src/AuthEndpoints/AuthEndpoints.csproj
+++ b/src/AuthEndpoints/AuthEndpoints.csproj
@@ -6,14 +6,14 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Description>Auth library that provides a set of minimal api endpoints to handle authentication actions</Description>
-    <Version>3.0.0-rc.4</Version>
+    <Version>3.0.0</Version>
     <Authors>madeyoga</Authors>
     <Company>madeyoga</Company>
     <PackageProjectUrl>https://github.com/madeyoga/AuthEndpoints</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/madeyoga/AuthEndpoints</RepositoryUrl>
     <PackageTags>auth;endpoints;aspnetcore;jwt;passkey;webauthn;2fa;identity</PackageTags>
-    <PackageReleaseNotes></PackageReleaseNotes>
+    <PackageReleaseNotes>AuthEndpoints 3.0: opinionated AddAuthEndpoints/UseAuthEndpoints/MapAuthEndpoints facade; cookie, Identity bearer, and Simple JWT sign-in; passkeys (WebAuthn) with pluggable IPasskeySignInCompleter; 2FA; ReAuth step-up; .NET 10.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cuts **AuthEndpoints 3.0.0** (first stable of the 3.0 line) and keeps **AuthEndpoints.External.OAuth** as a preview package retargeted at that core.

This is a version and docs cut. Last feature work was rc.4 (`IPasskeySignInCompleter`). No auth behavior changes.

### Packages

| Package | Before | After |
| --- | --- | --- |
| `AuthEndpoints` | `3.0.0-rc.4` (already on nuget.org) | **`3.0.0`** |
| `AuthEndpoints.External.OAuth` | `3.0.0-preview.2` (nupkg depends on `AuthEndpoints 3.0.0-rc.2`) | **`3.0.0-preview.3`** (packed nupkg depends on `AuthEndpoints 3.0.0`) |

OAuth stays preview. Bumping to `preview.3` is required: packing the solution always uses the current core `Version`, and `--skip-duplicate` would leave the published `preview.2` nupkg on nuget.org still depending on rc.2.

`PackageReleaseNotes` on the core package is a short 3.0 GA summary (facade, cookie / Identity bearer / Simple JWT, passkeys including pluggable completer, 2FA, ReAuth, .NET 10).

### Docs

- Drop `--prerelease` from user-facing AuthEndpoints install (`README.md`, installation docs, External OAuth module page). Keep `--prerelease` for External.OAuth.
- NuGet badge for the core package is `nuget/v` (stable) instead of `vpre`.
- Changelog: add `Documentation/content/versions/v3.0.0.md` and `external-oauth-v3.0.0-preview.3.md`. Move the changelog **Latest** badge from rc.3 to 3.0.0. Remove the stale “pending publish” line on rc.4.
- `Documentation/README.md` typical core tag example is now `v3.0.0`.
- Remaining “3.0 RC or later” language in OAuth install notes now says **3.0.0 or later**.

### Publishing (after merge — not part of this PR)

Publishing is still triggered by a GitHub release (`.github/workflows/publish-to-nuget.yml`). This PR does **not** create a GitHub release, tag, or NuGet publish.

After merge, create:

1. GitHub release tag **`v3.0.0`** to publish `AuthEndpoints` 3.0.0
2. GitHub release tag **`external-oauth-v3.0.0-preview.3`** to publish the retargeted OAuth preview

Until those tags exist, `dotnet add package AuthEndpoints` still installs the last stable on nuget.org (`2.2.0`).

## Test plan

- [x] `dotnet test AuthEndpoints.sln` is green — **69 passed, 0 failed** (no auth behavior changes)
- [x] `dotnet pack AuthEndpoints.sln -c Release` produces `AuthEndpoints.3.0.0.nupkg` and `AuthEndpoints.External.OAuth.3.0.0-preview.3.nupkg`
- [x] Packed OAuth nuspec depends on `AuthEndpoints` `3.0.0` (not `3.0.0-rc.2`)
- [x] Core nuspec `releaseNotes` is the 3.0 GA summary
- [x] README / installation docs install core without `--prerelease`; External.OAuth still uses `--prerelease`
- [x] Changelog pages `v3.0.0` and `external-oauth-v3.0.0-preview.3` follow existing frontmatter (`title`, `description`, `date`, `tag`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3812926b-06de-4ec6-8ffa-6772ade6d482?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3812926b-06de-4ec6-8ffa-6772ade6d482&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

