### PR TITLE
Docs SEO/AEO: sitemap, canonicals, JSON-LD, and prerendered 404

### DIFF
--- a/Documentation/app/app.config.ts
+++ b/Documentation/app/app.config.ts
@@ -27,7 +27,7 @@ export default defineAppConfig({
     links: [{
       'label': 'Changelog',
       'icon': 'i-lucide-scroll-text',
-      'to': '/changelog',
+      'to': '/changelog/',
       'aria-label': 'Changelog'
     }, {
       'icon': 'i-simple-icons-github',

--- a/Documentation/app/app.vue
+++ b/Documentation/app/app.vue
@@ -1,28 +1,10 @@
 <script setup lang="ts">
-const { seo } = useAppConfig()
-
 const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs'))
 const { data: files } = useLazyAsyncData('search', () => queryCollectionSearchSections('docs'), {
   server: false
 })
 
-useHead({
-  meta: [
-    { name: 'viewport', content: 'width=device-width, initial-scale=1' }
-  ],
-  link: [
-    { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }
-  ],
-  htmlAttrs: {
-    lang: 'en'
-  }
-})
-
-useSeoMeta({
-  titleTemplate: `%s - ${seo?.siteName}`,
-  ogSiteName: seo?.siteName,
-  twitterCard: 'summary_large_image'
-})
+useDocsSiteHead()
 
 provide('navigation', navigation)
 </script>

--- a/Documentation/app/components/OgImage/Docs.takumi.vue
+++ b/Documentation/app/components/OgImage/Docs.takumi.vue
@@ -57,7 +57,7 @@ defineProps<{
           />
         </svg>
         <div class="h-px flex-1 bg-border" />
-        <span class="text-xl text-dimmed">ui.nuxt.com</span>
+        <span class="text-xl text-dimmed">AuthEndpoints</span>
       </div>
     </div>
   </div>

--- a/Documentation/app/components/PageHeaderLinks.vue
+++ b/Documentation/app/components/PageHeaderLinks.vue
@@ -6,7 +6,7 @@ const toast = useToast()
 const { copy, copied } = useClipboard()
 const site = useSiteConfig()
 
-const mdPath = computed(() => `${site.url}/raw${route.path}.md`)
+const mdPath = computed(() => `${String(site.url || '').replace(/\/$/, '')}/raw${route.path}.md`)
 
 const items = [
   {
@@ -24,7 +24,8 @@ const items = [
     label: 'View as Markdown',
     icon: 'i-simple-icons:markdown',
     target: '_blank',
-    to: `/raw${route.path}.md`
+    to: `/raw${route.path}.md`,
+    trailingSlash: 'remove'
   },
   {
     label: 'Open in ChatGPT',

--- a/Documentation/app/components/PageHeaderLinks.vue
+++ b/Documentation/app/components/PageHeaderLinks.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
+import { DOCS_SITE_URL } from '#shared/site'
 
 const route = useRoute()
 const toast = useToast()
 const { copy, copied } = useClipboard()
-const site = useSiteConfig()
 
-const mdPath = computed(() => `${String(site.url || '').replace(/\/$/, '')}/raw${route.path}.md`)
+const mdPath = computed(() => `${DOCS_SITE_URL}/raw${route.path}.md`)
 
 const items = [
   {
@@ -25,7 +25,7 @@ const items = [
     icon: 'i-simple-icons:markdown',
     target: '_blank',
     to: `/raw${route.path}.md`,
-    trailingSlash: 'remove'
+    trailingSlash: 'remove' as const
   },
   {
     label: 'Open in ChatGPT',

--- a/Documentation/app/components/PageHeaderLinks.vue
+++ b/Documentation/app/components/PageHeaderLinks.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
-import { DOCS_SITE_URL } from '#shared/site'
+import { DOCS_SITE_URL, toRawMarkdownPath } from '#shared/site'
 
 const route = useRoute()
 const toast = useToast()
 const { copy, copied } = useClipboard()
 
-const mdPath = computed(() => `${DOCS_SITE_URL}/raw${route.path}.md`)
+const rawPath = computed(() => toRawMarkdownPath(route.path))
+const mdPath = computed(() => `${DOCS_SITE_URL}${rawPath.value}`)
 
-const items = [
+const items = computed(() => [
   {
     label: 'Copy Markdown link',
     icon: 'i-lucide-link',
@@ -24,7 +25,7 @@ const items = [
     label: 'View as Markdown',
     icon: 'i-simple-icons:markdown',
     target: '_blank',
-    to: `/raw${route.path}.md`,
+    to: rawPath.value,
     trailingSlash: 'remove' as const
   },
   {
@@ -39,10 +40,10 @@ const items = [
     target: '_blank',
     to: `https://claude.ai/new?q=${encodeURIComponent(`Read ${mdPath.value} so I can ask questions about it.`)}`
   }
-]
+])
 
 async function copyPage() {
-  copy(await $fetch<string>(`/raw${route.path}.md`))
+  copy(await $fetch<string>(rawPath.value))
 }
 </script>
 

--- a/Documentation/app/components/PageHeaderLinks.vue
+++ b/Documentation/app/components/PageHeaderLinks.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
-import { DOCS_SITE_URL, toRawMarkdownPath } from '#shared/site'
+import { DOCS_SITE_URL, toRawMarkdownHref, toRawMarkdownPath } from '#shared/site'
 
 const route = useRoute()
 const toast = useToast()
 const { copy, copied } = useClipboard()
+const { app } = useRuntimeConfig()
 
 const rawPath = computed(() => toRawMarkdownPath(route.path))
+const rawHref = computed(() => toRawMarkdownHref(route.path, app.baseURL))
 const mdPath = computed(() => `${DOCS_SITE_URL}${rawPath.value}`)
 
 const items = computed(() => [
@@ -25,7 +27,8 @@ const items = computed(() => [
     label: 'View as Markdown',
     icon: 'i-simple-icons:markdown',
     target: '_blank',
-    to: rawPath.value,
+    external: true,
+    to: rawHref.value,
     trailingSlash: 'remove' as const
   },
   {
@@ -43,7 +46,7 @@ const items = computed(() => [
 ])
 
 async function copyPage() {
-  copy(await $fetch<string>(rawPath.value))
+  copy(await $fetch<string>(rawHref.value))
 }
 </script>
 

--- a/Documentation/app/composables/useDocsSeo.ts
+++ b/Documentation/app/composables/useDocsSeo.ts
@@ -52,22 +52,22 @@ export function useSoftwareJsonLd() {
       innerHTML: JSON.stringify({
         '@context': 'https://schema.org',
         '@type': ['SoftwareApplication', 'SoftwareSourceCode'],
-        name: SITE_NAME,
-        alternateName: SITE_TITLE,
-        description: SITE_DESCRIPTION,
-        url: toCanonicalUrl('/'),
-        applicationCategory: 'DeveloperApplication',
-        operatingSystem: 'ASP.NET Core',
-        programmingLanguage: 'C#',
-        runtimePlatform: '.NET 10',
-        license: 'https://opensource.org/licenses/MIT',
-        codeRepository: 'https://github.com/madeyoga/AuthEndpoints',
-        downloadUrl: 'https://www.nuget.org/packages/AuthEndpoints/',
-        isAccessibleForFree: true,
-        author: {
+        'name': SITE_NAME,
+        'alternateName': SITE_TITLE,
+        'description': SITE_DESCRIPTION,
+        'url': toCanonicalUrl('/'),
+        'applicationCategory': 'DeveloperApplication',
+        'operatingSystem': 'ASP.NET Core',
+        'programmingLanguage': 'C#',
+        'runtimePlatform': '.NET 10',
+        'license': 'https://opensource.org/licenses/MIT',
+        'codeRepository': 'https://github.com/madeyoga/AuthEndpoints',
+        'downloadUrl': 'https://www.nuget.org/packages/AuthEndpoints/',
+        'isAccessibleForFree': true,
+        'author': {
           '@type': 'Person',
-          name: 'madeyoga',
-          url: 'https://github.com/madeyoga'
+          'name': 'madeyoga',
+          'url': 'https://github.com/madeyoga'
         }
       })
     }]
@@ -86,24 +86,24 @@ export function useTechArticleJsonLd(input: { title: string, description?: strin
         innerHTML: JSON.stringify({
           '@context': 'https://schema.org',
           '@type': 'TechArticle',
-          headline: input.title,
-          description: input.description,
+          'headline': input.title,
+          'description': input.description,
           url,
-          mainEntityOfPage: url,
-          inLanguage: 'en',
-          isPartOf: {
+          'mainEntityOfPage': url,
+          'inLanguage': 'en',
+          'isPartOf': {
             '@type': 'WebSite',
-            name: SITE_NAME,
-            url: toCanonicalUrl('/')
+            'name': SITE_NAME,
+            'url': toCanonicalUrl('/')
           },
-          about: {
+          'about': {
             '@type': 'SoftwareApplication',
-            name: SITE_NAME,
-            url: toCanonicalUrl('/'),
-            downloadUrl: 'https://www.nuget.org/packages/AuthEndpoints/',
-            license: 'https://opensource.org/licenses/MIT'
+            'name': SITE_NAME,
+            'url': toCanonicalUrl('/'),
+            'downloadUrl': 'https://www.nuget.org/packages/AuthEndpoints/',
+            'license': 'https://opensource.org/licenses/MIT'
           },
-          license: 'https://opensource.org/licenses/MIT'
+          'license': 'https://opensource.org/licenses/MIT'
         })
       }]
     }

--- a/Documentation/app/composables/useDocsSeo.ts
+++ b/Documentation/app/composables/useDocsSeo.ts
@@ -1,0 +1,111 @@
+import { joinURL } from 'ufo'
+import {
+  SITE_NAME,
+  SITE_TITLE,
+  SITE_DESCRIPTION,
+  toCanonicalUrl
+} from '#shared/site'
+
+export function useDocsCanonical() {
+  const route = useRoute()
+  const canonical = computed(() => toCanonicalUrl(route.path))
+  return { canonical }
+}
+
+export function useDocsSiteHead() {
+  const { seo } = useAppConfig()
+  const { app } = useRuntimeConfig()
+  const { canonical } = useDocsCanonical()
+
+  const favicon = computed(() => joinURL(app.baseURL, 'favicon.svg'))
+  const sitemapHref = computed(() => joinURL(app.baseURL, 'sitemap.xml'))
+
+  useHead({
+    htmlAttrs: {
+      lang: 'en'
+    },
+    titleTemplate: (titleChunk) => {
+      if (!titleChunk || titleChunk === SITE_NAME || titleChunk === SITE_TITLE) {
+        return SITE_TITLE
+      }
+      return `${titleChunk} - ${seo?.siteName || SITE_NAME}`
+    },
+    link: [
+      { rel: 'icon', href: favicon, type: 'image/svg+xml' },
+      { rel: 'canonical', href: canonical },
+      { rel: 'sitemap', type: 'application/xml', title: 'Sitemap', href: sitemapHref }
+    ]
+  })
+
+  useSeoMeta({
+    ogSiteName: seo?.siteName || SITE_NAME,
+    ogUrl: canonical,
+    twitterCard: 'summary_large_image'
+  })
+}
+
+export function useSoftwareJsonLd() {
+  useHead({
+    script: [{
+      key: 'ld-json',
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': ['SoftwareApplication', 'SoftwareSourceCode'],
+        name: SITE_NAME,
+        alternateName: SITE_TITLE,
+        description: SITE_DESCRIPTION,
+        url: toCanonicalUrl('/'),
+        applicationCategory: 'DeveloperApplication',
+        operatingSystem: 'ASP.NET Core',
+        programmingLanguage: 'C#',
+        runtimePlatform: '.NET 10',
+        license: 'https://opensource.org/licenses/MIT',
+        codeRepository: 'https://github.com/madeyoga/AuthEndpoints',
+        downloadUrl: 'https://www.nuget.org/packages/AuthEndpoints/',
+        isAccessibleForFree: true,
+        author: {
+          '@type': 'Person',
+          name: 'madeyoga',
+          url: 'https://github.com/madeyoga'
+        }
+      })
+    }]
+  })
+}
+
+export function useTechArticleJsonLd(input: { title: string, description?: string }) {
+  const route = useRoute()
+
+  useHead(() => {
+    const url = toCanonicalUrl(route.path)
+    return {
+      script: [{
+        key: 'ld-json',
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'TechArticle',
+          headline: input.title,
+          description: input.description,
+          url,
+          mainEntityOfPage: url,
+          inLanguage: 'en',
+          isPartOf: {
+            '@type': 'WebSite',
+            name: SITE_NAME,
+            url: toCanonicalUrl('/')
+          },
+          about: {
+            '@type': 'SoftwareApplication',
+            name: SITE_NAME,
+            url: toCanonicalUrl('/'),
+            downloadUrl: 'https://www.nuget.org/packages/AuthEndpoints/',
+            license: 'https://opensource.org/licenses/MIT'
+          },
+          license: 'https://opensource.org/licenses/MIT'
+        })
+      }]
+    }
+  })
+}

--- a/Documentation/app/error.vue
+++ b/Documentation/app/error.vue
@@ -1,25 +1,41 @@
 <script setup lang="ts">
 import type { NuxtError } from '#app'
+import { joinURL } from 'ufo'
 
-defineProps<{
+const props = defineProps<{
   error: NuxtError
 }>()
+
+const { app } = useRuntimeConfig()
 
 useHead({
   htmlAttrs: {
     lang: 'en'
-  }
+  },
+  titleTemplate: '%s',
+  link: [
+    { rel: 'icon', href: joinURL(app.baseURL, 'favicon.svg'), type: 'image/svg+xml' }
+  ]
 })
 
 useSeoMeta({
   title: 'Page not found',
-  description: 'We are sorry but this page could not be found.'
+  description: 'This documentation page does not exist.',
+  robots: 'noindex, nofollow'
 })
 
 const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs'))
 const { data: files } = useLazyAsyncData('search', () => queryCollectionSearchSections('docs'), {
   server: false
 })
+
+const displayError = computed(() => ({
+  statusCode: props.error?.statusCode || 404,
+  statusMessage: props.error?.statusMessage || 'Page not found',
+  message: props.error?.message && props.error.message !== props.error.statusMessage
+    ? props.error.message
+    : 'This documentation page does not exist.'
+}))
 
 provide('navigation', navigation)
 </script>
@@ -28,7 +44,11 @@ provide('navigation', navigation)
   <UApp>
     <AppHeader />
 
-    <UError :error="error" />
+    <UError
+      :error="displayError"
+      redirect="/"
+      :clear="{ label: 'Docs home', size: 'lg' }"
+    />
 
     <AppFooter />
 

--- a/Documentation/app/pages/404.vue
+++ b/Documentation/app/pages/404.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+useSeoMeta({
+  title: 'Page not found',
+  description: 'This documentation page does not exist.',
+  robots: 'noindex, nofollow'
+})
+</script>
+
+<template>
+  <UError
+    :error="{
+      statusCode: 404,
+      statusMessage: 'Page not found',
+      message: 'This documentation page does not exist.'
+    }"
+    redirect="/"
+    :clear="{ label: 'Docs home', size: 'lg' }"
+  />
+</template>

--- a/Documentation/app/pages/[...slug].vue
+++ b/Documentation/app/pages/[...slug].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ContentNavigationItem } from '@nuxt/content'
 import { findPageHeadline } from '@nuxt/content/utils'
+import { toContentPath } from '#shared/site'
 
 definePageMeta({
   layout: 'docs'
@@ -10,16 +11,22 @@ const route = useRoute()
 const { toc } = useAppConfig()
 const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
 
-const { data: page } = await useAsyncData(route.path, () => queryCollection('docs').path(route.path).first())
+const contentPath = computed(() => toContentPath(route.path))
+
+const { data: page } = await useAsyncData(
+  () => contentPath.value,
+  () => queryCollection('docs').path(contentPath.value).first()
+)
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const { data: surround } = await useAsyncData(`${route.path}-surround`, () => {
-  return queryCollectionItemSurroundings('docs', route.path, {
+const { data: surround } = await useAsyncData(
+  () => `${contentPath.value}-surround`,
+  () => queryCollectionItemSurroundings('docs', contentPath.value, {
     fields: ['description']
   })
-})
+)
 
 const title = page.value.seo?.title || page.value.title
 const description = page.value.seo?.description || page.value.description

--- a/Documentation/app/pages/[...slug].vue
+++ b/Documentation/app/pages/[...slug].vue
@@ -28,8 +28,11 @@ useSeoMeta({
   title,
   ogTitle: title,
   description,
-  ogDescription: description
+  ogDescription: description,
+  ogType: 'article'
 })
+
+useTechArticleJsonLd({ title, description })
 
 const headline = computed(() => findPageHeadline(navigation?.value, page.value?.path))
 

--- a/Documentation/app/pages/changelog.vue
+++ b/Documentation/app/pages/changelog.vue
@@ -3,12 +3,24 @@ const { data: versions } = await useAsyncData('changelog-versions', () =>
   queryCollection('versions').order('date', 'DESC').all()
 )
 
+const title = 'Changelog'
+const description = 'Release notes for AuthEndpoints — Identity auth endpoints for ASP.NET Core.'
+
 useSeoMeta({
-  title: 'Changelog',
-  description: 'Release notes for AuthEndpoints — Identity auth endpoints for ASP.NET Core.',
+  title,
+  description,
   ogTitle: 'Changelog - AuthEndpoints',
-  ogDescription: 'Release notes for AuthEndpoints — Identity auth endpoints for ASP.NET Core.'
+  ogDescription: description,
+  ogType: 'article'
 })
+
+defineOgImage('Docs', {
+  title,
+  description,
+  headline: 'Releases'
+})
+
+useTechArticleJsonLd({ title, description })
 
 function releaseUrl(version: { tag?: string, title?: string }) {
   const tag = version.tag || version.title
@@ -49,7 +61,7 @@ function badgeProps(badge?: string) {
         size: 'lg'
       }, {
         label: 'Get started',
-        to: '/getting-started',
+        to: '/getting-started/',
         trailingIcon: 'i-lucide-arrow-right',
         size: 'lg'
       }]"

--- a/Documentation/app/pages/index.vue
+++ b/Documentation/app/pages/index.vue
@@ -8,12 +8,20 @@ const title = page.value.seo?.title || page.value.title
 const description = page.value.seo?.description || page.value.description
 
 useSeoMeta({
-  titleTemplate: '',
   title,
   ogTitle: title,
   description,
-  ogDescription: description
+  ogDescription: description,
+  ogType: 'website'
 })
+
+defineOgImage('Docs', {
+  title: 'AuthEndpoints',
+  description,
+  headline: 'ASP.NET Core'
+})
+
+useSoftwareJsonLd()
 </script>
 
 <template>

--- a/Documentation/content/1.getting-started/1.index.md
+++ b/Documentation/content/1.getting-started/1.index.md
@@ -45,3 +45,8 @@ See [Quick start](/getting-started/quick-start) for the facade, and [Composable 
 - .NET 10
 - ASP.NET Core Identity
 - EF Core for the user store
+
+## Next
+
+- [AuthEndpoints compared](/getting-started/compare) — Identity yourself, OpenIddict, and `MapIdentityApi`
+- [FAQ](/getting-started/faq)

--- a/Documentation/content/1.getting-started/6.compare.md
+++ b/Documentation/content/1.getting-started/6.compare.md
@@ -1,0 +1,26 @@
+---
+title: AuthEndpoints compared
+description: How AuthEndpoints differs from wiring ASP.NET Core Identity yourself, from OpenIddict, and from Identity API endpoints.
+navigation:
+  icon: i-lucide-git-compare
+---
+
+AuthEndpoints is a first-party auth API on top of ASP.NET Core Identity. Use it when you own the users. Use something else when you need an OAuth or OpenID Connect server, or when Microsoft's Identity API endpoints already cover the whole job.
+
+## vs wiring Identity yourself
+
+You still use Identity, EF Core, and your user type. AuthEndpoints maps the endpoints you would otherwise write: register, login, 2FA, password reset, passkeys. You skip the week of copy-paste and the easy-to-miss hardening.
+
+## vs OpenIddict
+
+OpenIddict is an OAuth 2 and OpenID Connect server. Use it when other apps sign in to you as a provider. AuthEndpoints is for your own web and mobile clients talking to your API. First-party cookies or tokens, not a federation server.
+
+## vs Identity API endpoints (`MapIdentityApi`)
+
+Identity API endpoints give you a bearer-token first-party API. AuthEndpoints covers that job and the cookie-app job, plus passkeys, composable modules, and hardening defaults (rate limits, antiforgery, lockout, refresh-token reuse detection). Use `MapIdentityApi` if the framework sample is enough. Use AuthEndpoints if you need cookies, passkeys, or to compose only the routes you need.
+
+## Related
+
+- [Quick start](/getting-started/quick-start)
+- [Composable endpoints](/composables)
+- [FAQ](/getting-started/faq)

--- a/Documentation/content/1.getting-started/7.faq.md
+++ b/Documentation/content/1.getting-started/7.faq.md
@@ -1,0 +1,42 @@
+---
+title: AuthEndpoints FAQ
+description: Does AuthEndpoints replace Identity? Cookie or JWT? Passkeys, 2FA, composing routes, and Sign in with Google as a provider.
+navigation:
+  icon: i-lucide-circle-help
+---
+
+## Does this replace ASP.NET Core Identity?
+
+No. It maps endpoints on top of Identity. You still have Identity, your user type, and EF Core.
+
+## Cookie sessions or JWT?
+
+Both. Cookies for a first-party web app on the same site. JWT or Identity bearer tokens for mobile and SPA clients. Compose one stack or both.
+
+## Are passkeys included?
+
+Yes. WebAuthn register and login. Set `Passkeys.ServerDomain` in Production. Passkeys sit next to password and 2FA. They do not replace Identity.
+
+## How does 2FA work?
+
+Through Identity's 2FA. Endpoints for enable, recovery, and step-up ReAuth. Lockout-aware login is on by default.
+
+## Can I map only some of the endpoints?
+
+Yes. Start with the facade, then compose modules and prefixes when you need a custom path or a JWT-only API.
+
+## Can this be my Sign in with Google provider for other apps?
+
+No. Optional GitHub and Google login into your app is `AuthEndpoints.External.OAuth`. If other apps need to treat you as the identity provider, that is OpenIddict (or similar), not this library.
+
+::callout{icon="i-lucide-flask-conical" color="warning"}
+[External OAuth](/modules/external-oauth) is a **preview** package with its own version. It is not included in the core `AuthEndpoints` NuGet package.
+::
+
+## Related
+
+- [AuthEndpoints compared](/getting-started/compare)
+- [Quick start](/getting-started/quick-start)
+- [Composable endpoints](/composables)
+- [Passkeys](/modules/passkeys)
+- [Production](/getting-started/production)

--- a/Documentation/content/index.md
+++ b/Documentation/content/index.md
@@ -1,6 +1,6 @@
 ---
 seo:
-  title: AuthEndpoints
+  title: AuthEndpoints — ASP.NET Core Identity auth library
   description: Ready-made ASP.NET Core Identity auth endpoints for web and mobile clients — cookies, JWT, passkeys, and composable modules.
 ---
 

--- a/Documentation/content/index.md
+++ b/Documentation/content/index.md
@@ -1,7 +1,7 @@
 ---
 seo:
   title: AuthEndpoints — ASP.NET Core Identity auth library
-  description: Ready-made ASP.NET Core Identity auth endpoints for web and mobile clients — cookies, JWT, passkeys, and composable modules.
+  description: Ready-made auth endpoints on top of ASP.NET Core Identity, not a replacement. Cookies, JWT, and passkeys for first-party web and mobile apps.
 ---
 
 ::u-page-hero{class="dark:bg-gradient-to-b from-zinc-900 to-zinc-950"}
@@ -15,7 +15,7 @@ orientation: horizontal
 [AuthEndpoints]{.text-primary}
 
 #description
-Ready-made ASP.NET Core Identity auth endpoints for web and mobile clients. Map cookie, JWT, and passkey flows — or compose only what you need.
+Ready-made auth endpoints on top of ASP.NET Core Identity, not a replacement. Cookies, JWT, and passkeys for first-party web and mobile apps.
 
 #links
   :::u-button

--- a/Documentation/content/versions/external-oauth-v3.0.0-preview.1.md
+++ b/Documentation/content/versions/external-oauth-v3.0.0-preview.1.md
@@ -17,4 +17,4 @@ tag: external-oauth-v3.0.0-preview.1
 ### Links
 
 - [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/external-oauth-v3.0.0-preview.1)
-- [External OAuth docs](https://madeyoga.github.io/AuthEndpoints/modules/external-oauth)
+- [External OAuth docs](/modules/external-oauth/)

--- a/Documentation/content/versions/external-oauth-v3.0.0-preview.2.md
+++ b/Documentation/content/versions/external-oauth-v3.0.0-preview.2.md
@@ -20,4 +20,4 @@ tag: external-oauth-v3.0.0-preview.2
 ### Links
 
 - [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/external-oauth-v3.0.0-preview.2)
-- [External OAuth docs](https://madeyoga.github.io/AuthEndpoints/modules/external-oauth)
+- [External OAuth docs](/modules/external-oauth/)

--- a/Documentation/content/versions/external-oauth-v3.0.0-preview.3.md
+++ b/Documentation/content/versions/external-oauth-v3.0.0-preview.3.md
@@ -15,4 +15,4 @@ tag: external-oauth-v3.0.0-preview.3
 
 - [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/external-oauth-v3.0.0-preview.3)
 - [Compare](https://github.com/madeyoga/AuthEndpoints/compare/external-oauth-v3.0.0-preview.2...external-oauth-v3.0.0-preview.3)
-- [External OAuth docs](https://madeyoga.github.io/AuthEndpoints/modules/external-oauth)
+- [External OAuth docs](/modules/external-oauth/)

--- a/Documentation/nuxt.config.ts
+++ b/Documentation/nuxt.config.ts
@@ -22,14 +22,15 @@ export default defineNuxtConfig({
     baseURL: process.env.NUXT_APP_BASE_URL || '/'
   },
 
+  css: ['~/assets/css/main.css'],
+
   site: {
-    url: 'https://madeyoga.github.io/AuthEndpoints',
+    // Origin only — nuxt-site-config / og-image append app.baseURL (/AuthEndpoints/).
+    url: 'https://madeyoga.github.io',
     name: 'AuthEndpoints',
     trailingSlash: true,
     indexable: true
   },
-
-  css: ['~/assets/css/main.css'],
 
   content: {
     build: {
@@ -79,11 +80,12 @@ export default defineNuxtConfig({
     }
   },
 
+  routeRules: {
+    '/sitemap.xml': { prerender: true }
+  },
+
   experimental: {
     asyncContext: true,
-    // Server-render error.vue into 404.html so GitHub Pages keeps HTTP 404
-    // without shipping an empty SPA shell.
-    prerenderErrorPages: true,
     defaults: {
       nuxtLink: {
         trailingSlash: 'append'
@@ -99,14 +101,25 @@ export default defineNuxtConfig({
       routes: [
         '/',
         '/changelog',
-        '/sitemap.xml'
+        '/sitemap.xml',
+        '/404'
       ],
       crawlLinks: true
     }
   },
 
-  routeRules: {
-    '/sitemap.xml': { prerender: true }
+  hooks: {
+    'nitro:init'(nitro) {
+      nitro.hooks.hook('prerender:done', async () => {
+        const { copyFile, rm } = await import('node:fs/promises')
+        const { join } = await import('node:path')
+        const publicDir = nitro.options.output.publicDir
+        // github-pages emits an empty SPA 404.html; replace it with the prerendered error page
+        // and drop /404/ so that path is also a real HTTP 404 on Pages.
+        await copyFile(join(publicDir, '404/index.html'), join(publicDir, '404.html'))
+        await rm(join(publicDir, '404'), { recursive: true, force: true })
+      })
+    }
   },
 
   eslint: {

--- a/Documentation/nuxt.config.ts
+++ b/Documentation/nuxt.config.ts
@@ -1,4 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import rehypeOwnPropertyLinks from './rehype/own-property-links'
+import { isOwnPropertyHref } from './shared/site'
+
 export default defineNuxtConfig({
   modules: [
     '@nuxt/eslint',
@@ -17,6 +20,13 @@ export default defineNuxtConfig({
   app: {
     // CI sets NUXT_APP_BASE_URL=/AuthEndpoints/ for GitHub Pages project site.
     baseURL: process.env.NUXT_APP_BASE_URL || '/'
+  },
+
+  site: {
+    url: 'https://madeyoga.github.io/AuthEndpoints',
+    name: 'AuthEndpoints',
+    trailingSlash: true,
+    indexable: true
   },
 
   css: ['~/assets/css/main.css'],
@@ -45,6 +55,22 @@ export default defineNuxtConfig({
             'csharp',
             'cs'
           ]
+        },
+        rehypePlugins: {
+          'rehype-external-links': {
+            options: {
+              rel(node: { properties?: { href?: unknown } }) {
+                const href = typeof node.properties?.href === 'string' ? node.properties.href : ''
+                if (isOwnPropertyHref(href)) {
+                  return []
+                }
+                return ['nofollow']
+              }
+            }
+          },
+          'rehype-own-property-links': {
+            instance: rehypeOwnPropertyLinks
+          }
         }
       }
     },
@@ -54,7 +80,15 @@ export default defineNuxtConfig({
   },
 
   experimental: {
-    asyncContext: true
+    asyncContext: true,
+    // Server-render error.vue into 404.html so GitHub Pages keeps HTTP 404
+    // without shipping an empty SPA shell.
+    prerenderErrorPages: true,
+    defaults: {
+      nuxtLink: {
+        trailingSlash: 'append'
+      }
+    }
   },
 
   compatibilityDate: '2026-06-30',
@@ -64,10 +98,15 @@ export default defineNuxtConfig({
     prerender: {
       routes: [
         '/',
-        '/changelog'
+        '/changelog',
+        '/sitemap.xml'
       ],
       crawlLinks: true
     }
+  },
+
+  routeRules: {
+    '/sitemap.xml': { prerender: true }
   },
 
   eslint: {

--- a/Documentation/nuxt.config.ts
+++ b/Documentation/nuxt.config.ts
@@ -134,7 +134,7 @@ export default defineNuxtConfig({
   llms: {
     domain: 'https://madeyoga.github.io/AuthEndpoints',
     title: 'AuthEndpoints',
-    description: 'ASP.NET Core library of ready-made Identity auth endpoints for web and mobile clients — cookies, JWT, passkeys, and composable modules.',
+    description: 'Ready-made auth endpoints on top of ASP.NET Core Identity, not a replacement. Cookies, JWT, and passkeys for first-party web and mobile apps.',
     full: {
       title: 'AuthEndpoints - Full Documentation',
       description: 'Complete documentation for AuthEndpoints: getting started, composable endpoints, and module reference.'

--- a/Documentation/rehype/own-property-links.ts
+++ b/Documentation/rehype/own-property-links.ts
@@ -1,0 +1,68 @@
+import { visit } from 'unist-util-visit'
+import { isOwnPropertyHref, toCanonicalUrl, DOCS_SITE_URL, DOCS_BASE_PATH } from '../shared/site'
+
+interface HastElement {
+  type: string
+  tagName?: string
+  properties?: {
+    href?: unknown
+    rel?: unknown
+    [key: string]: unknown
+  }
+}
+
+function relList(value: unknown): string[] {
+  if (!value) {
+    return []
+  }
+  if (Array.isArray(value)) {
+    return value.map(String).flatMap(part => part.split(/\s+/)).filter(Boolean)
+  }
+  return String(value).split(/\s+/).filter(Boolean)
+}
+
+function toInternalDocsPath(href: string): string | undefined {
+  if (href.startsWith(DOCS_SITE_URL)) {
+    const rest = href.slice(DOCS_SITE_URL.length) || '/'
+    return rest.startsWith('/') ? rest : `/${rest}`
+  }
+  if (href.startsWith(DOCS_BASE_PATH + '/') || href === DOCS_BASE_PATH) {
+    const rest = href.slice(DOCS_BASE_PATH.length) || '/'
+    return rest.startsWith('/') ? rest : `/${rest}`
+  }
+  return undefined
+}
+
+/**
+ * Keep rel=nofollow on unrelated externals, but drop it on first-party docs,
+ * GitHub repo/releases, and the NuGet package page. Also rewrite absolute
+ * github.io docs URLs to in-app paths so they pick up trailing slashes.
+ */
+export default function rehypeOwnPropertyLinks() {
+  return (tree: unknown) => {
+    visit(tree as never, 'element', (node: HastElement) => {
+      if (node.tagName !== 'a' || !node.properties) {
+        return
+      }
+
+      const href = typeof node.properties.href === 'string' ? node.properties.href : ''
+      if (!href || !isOwnPropertyHref(href)) {
+        return
+      }
+
+      const internal = toInternalDocsPath(href)
+      if (internal) {
+        const canonical = toCanonicalUrl(internal)
+        const path = canonical.slice(DOCS_SITE_URL.length) || '/'
+        node.properties.href = path
+      }
+
+      const nextRel = relList(node.properties.rel).filter(token => token !== 'nofollow')
+      if (nextRel.length) {
+        node.properties.rel = nextRel
+      } else {
+        delete node.properties.rel
+      }
+    })
+  }
+}

--- a/Documentation/server/mcp/tools/get-page.ts
+++ b/Documentation/server/mcp/tools/get-page.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { queryCollection } from '@nuxt/content/server'
+import { toContentPath, toRawMarkdownPath } from '#shared/site'
 
 export default defineMcpTool({
   description: `Retrieves the full content and details of a specific documentation page.
@@ -21,10 +22,11 @@ WORKFLOW: This tool returns the complete page content including title, descripti
     const event = useEvent()
     const url = getRequestURL(event)
     const siteUrl = import.meta.dev ? `${url.protocol}//${url.hostname}:${url.port}` : url.origin
+    const contentPath = toContentPath(path)
 
     try {
       const page = await queryCollection(event, 'docs')
-        .where('path', '=', path)
+        .where('path', '=', contentPath)
         .select('title', 'path', 'description')
         .first()
 
@@ -35,7 +37,7 @@ WORKFLOW: This tool returns the complete page content including title, descripti
         }
       }
 
-      const content = await $fetch<string>(`/raw${path}.md`, {
+      const content = await $fetch<string>(toRawMarkdownPath(contentPath), {
         baseURL: siteUrl
       })
 

--- a/Documentation/server/routes/raw/[...slug].md.get.ts
+++ b/Documentation/server/routes/raw/[...slug].md.get.ts
@@ -2,6 +2,7 @@ import { withLeadingSlash } from 'ufo'
 import { stringify } from 'minimark/stringify'
 import { queryCollection } from '@nuxt/content/server'
 import type { Collections } from '@nuxt/content'
+import { toContentPath } from '#shared/site'
 
 export default eventHandler(async (event) => {
   const slug = getRouterParams(event)['slug.md']
@@ -9,7 +10,7 @@ export default eventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
   }
 
-  const path = withLeadingSlash(slug.replace('.md', ''))
+  const path = toContentPath(withLeadingSlash(slug.replace(/\.md$/i, '')))
 
   const page = await queryCollection(event, 'docs' as keyof Collections).path(path).first()
   if (!page) {

--- a/Documentation/server/routes/sitemap.xml.ts
+++ b/Documentation/server/routes/sitemap.xml.ts
@@ -1,0 +1,22 @@
+import { queryCollection } from '@nuxt/content/server'
+import { sitemapLocs } from '#shared/site'
+
+export default defineEventHandler(async (event) => {
+  const docs = await queryCollection(event, 'docs').select('path').all()
+  const locs = sitemapLocs([
+    '/',
+    '/changelog',
+    ...docs.map(page => page.path).filter((path): path is string => Boolean(path))
+  ])
+
+  const body = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...locs.map(loc => `  <url>\n    <loc>${loc}</loc>\n  </url>`),
+    '</urlset>',
+    ''
+  ].join('\n')
+
+  setHeader(event, 'Content-Type', 'application/xml; charset=utf-8')
+  return body
+})

--- a/Documentation/server/routes/sitemap.xml.ts
+++ b/Documentation/server/routes/sitemap.xml.ts
@@ -1,12 +1,12 @@
 import { queryCollection } from '@nuxt/content/server'
-import { sitemapLocs } from '#shared/site'
+import { sitemapLocs, isPublicDocsPath } from '#shared/site'
 
 export default defineEventHandler(async (event) => {
   const docs = await queryCollection(event, 'docs').select('path').all()
   const locs = sitemapLocs([
     '/',
     '/changelog',
-    ...docs.map(page => page.path).filter((path): path is string => Boolean(path))
+    ...docs.map(page => page.path).filter((path): path is string => Boolean(path) && isPublicDocsPath(path))
   ])
 
   const body = [

--- a/Documentation/shared/site.ts
+++ b/Documentation/shared/site.ts
@@ -5,7 +5,7 @@ export const DOCS_SITE_URL = `${DOCS_ORIGIN}${DOCS_BASE_PATH}`
 
 export const SITE_NAME = 'AuthEndpoints'
 export const SITE_TITLE = 'AuthEndpoints — ASP.NET Core Identity auth library'
-export const SITE_DESCRIPTION = 'Ready-made ASP.NET Core Identity auth endpoints for web and mobile clients — cookies, JWT, passkeys, and composable modules.'
+export const SITE_DESCRIPTION = 'Ready-made auth endpoints on top of ASP.NET Core Identity, not a replacement. Cookies, JWT, and passkeys for first-party web and mobile apps.'
 
 const OWN_URL_PREFIXES = [
   DOCS_SITE_URL,

--- a/Documentation/shared/site.ts
+++ b/Documentation/shared/site.ts
@@ -1,0 +1,127 @@
+/** Public GitHub Pages origin for the library docs (project site under /AuthEndpoints/). */
+export const DOCS_ORIGIN = 'https://madeyoga.github.io'
+export const DOCS_BASE_PATH = '/AuthEndpoints'
+export const DOCS_SITE_URL = `${DOCS_ORIGIN}${DOCS_BASE_PATH}`
+
+export const SITE_NAME = 'AuthEndpoints'
+export const SITE_TITLE = 'AuthEndpoints — ASP.NET Core Identity auth library'
+export const SITE_DESCRIPTION = 'Ready-made ASP.NET Core Identity auth endpoints for web and mobile clients — cookies, JWT, passkeys, and composable modules.'
+
+const OWN_URL_PREFIXES = [
+  DOCS_SITE_URL,
+  `${DOCS_ORIGIN}${DOCS_BASE_PATH}/`,
+  'https://github.com/madeyoga/AuthEndpoints',
+  'https://www.nuget.org/packages/AuthEndpoints',
+  'https://nuget.org/packages/AuthEndpoints'
+] as const
+
+/**
+ * Links that should not get rel=nofollow: this docs site, the GitHub repo/releases,
+ * and the NuGet package page. Unrelated externals can keep nofollow.
+ */
+export function isOwnPropertyHref(href: string | undefined | null): boolean {
+  if (!href) {
+    return false
+  }
+
+  const trimmed = href.trim()
+  if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('mailto:') || trimmed.startsWith('tel:')) {
+    return true
+  }
+
+  // In-app paths (including the Pages base URL) are first-party.
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
+    return true
+  }
+
+  return OWN_URL_PREFIXES.some((prefix) => {
+    const normalized = prefix.replace(/\/$/, '')
+    return trimmed === normalized
+      || trimmed === `${normalized}/`
+      || trimmed.startsWith(`${normalized}/`)
+      || trimmed.startsWith(`${normalized}?`)
+      || trimmed.startsWith(`${normalized}#`)
+  })
+}
+
+/** Drop a leading /AuthEndpoints prefix so canonicals can be built from route.path or request URLs. */
+export function stripDocsBasePath(path: string): string {
+  const pathname = path.split('?')[0]?.split('#')[0] || '/'
+  if (pathname === DOCS_BASE_PATH || pathname === `${DOCS_BASE_PATH}/`) {
+    return '/'
+  }
+  if (pathname.startsWith(`${DOCS_BASE_PATH}/`)) {
+    return pathname.slice(DOCS_BASE_PATH.length) || '/'
+  }
+  return pathname.startsWith('/') ? pathname : `/${pathname}`
+}
+
+function isFilePath(path: string): boolean {
+  const last = path.split('/').pop() || ''
+  return last.includes('.')
+}
+
+/** Absolute trailing-slash URL on the public docs host. */
+export function toCanonicalUrl(path: string): string {
+  const hashIndex = path.indexOf('#')
+  const hash = hashIndex >= 0 ? path.slice(hashIndex) : ''
+  const withoutHash = hashIndex >= 0 ? path.slice(0, hashIndex) : path
+  const pathname = stripDocsBasePath(withoutHash.split('?')[0] || '/')
+
+  if (pathname === '/' || pathname === '') {
+    return `${DOCS_SITE_URL}/${hash}`
+  }
+
+  if (isFilePath(pathname)) {
+    return `${DOCS_SITE_URL}${pathname}${hash}`
+  }
+
+  const withSlash = pathname.endsWith('/') ? pathname : `${pathname}/`
+  return `${DOCS_SITE_URL}${withSlash}${hash}`
+}
+
+export function withNavTrailingSlash(path: string | undefined | null): string | undefined {
+  if (!path) {
+    return path ?? undefined
+  }
+  if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('mailto:') || path.startsWith('#')) {
+    return path
+  }
+  const hashIndex = path.indexOf('#')
+  const hash = hashIndex >= 0 ? path.slice(hashIndex) : ''
+  const pathname = hashIndex >= 0 ? path.slice(0, hashIndex) : path
+  if (isFilePath(pathname) || pathname === '/') {
+    return `${pathname}${hash}`
+  }
+  return `${pathname.endsWith('/') ? pathname : `${pathname}/`}${hash}`
+}
+
+export function applyTrailingSlashToNav<T extends { path?: string, to?: unknown, children?: T[] }>(
+  items: T[] | undefined | null
+): T[] {
+  if (!items?.length) {
+    return []
+  }
+
+  return items.map((item) => {
+    const next = { ...item }
+    if (typeof next.path === 'string') {
+      next.path = withNavTrailingSlash(next.path)
+    }
+    if (typeof next.to === 'string') {
+      next.to = withNavTrailingSlash(next.to)
+    }
+    if (next.children?.length) {
+      next.children = applyTrailingSlashToNav(next.children)
+    }
+    return next
+  })
+}
+
+export function sitemapLocs(paths: Iterable<string>): string[] {
+  const unique = new Set<string>()
+  for (const path of paths) {
+    unique.add(toCanonicalUrl(path).split('#')[0]!)
+  }
+  return [...unique].sort((a, b) => a.localeCompare(b))
+}

--- a/Documentation/shared/site.ts
+++ b/Documentation/shared/site.ts
@@ -118,9 +118,23 @@ export function applyTrailingSlashToNav<T extends { path?: string, to?: unknown,
   })
 }
 
+export function isPublicDocsPath(path: string | undefined | null): boolean {
+  if (!path) {
+    return false
+  }
+  const pathname = stripDocsBasePath(path)
+  if (pathname === '/404' || pathname === '/404.html') {
+    return false
+  }
+  return !pathname.split('/').some(segment => segment.startsWith('.'))
+}
+
 export function sitemapLocs(paths: Iterable<string>): string[] {
   const unique = new Set<string>()
   for (const path of paths) {
+    if (!isPublicDocsPath(path)) {
+      continue
+    }
     unique.add(toCanonicalUrl(path).split('#')[0]!)
   }
   return [...unique].sort((a, b) => a.localeCompare(b))

--- a/Documentation/shared/site.ts
+++ b/Documentation/shared/site.ts
@@ -78,6 +78,13 @@ export function toRawMarkdownPath(path: string | undefined | null): string {
   return `/raw${toContentPath(path)}.md`
 }
 
+/** Resolve a raw markdown URL against the Pages base (`/AuthEndpoints/`). `.md` hrefs skip NuxtLink baseURL. */
+export function toRawMarkdownHref(path: string | undefined | null, baseURL = '/'): string {
+  const raw = toRawMarkdownPath(path).replace(/^\//, '')
+  const base = baseURL.endsWith('/') ? baseURL : `${baseURL}/`
+  return `${base}${raw}`
+}
+
 function isFilePath(path: string): boolean {
   const last = path.split('/').pop() || ''
   return last.includes('.')

--- a/Documentation/shared/site.ts
+++ b/Documentation/shared/site.ts
@@ -56,6 +56,28 @@ export function stripDocsBasePath(path: string): string {
   return pathname.startsWith('/') ? pathname : `/${pathname}`
 }
 
+/**
+ * Nuxt Content stores page paths without a trailing slash (`/getting-started`).
+ * Public URLs keep a slash (`/getting-started/`) via NuxtLink trailingSlash append,
+ * so Vue Router's route.path cannot be passed straight into collection queries.
+ */
+export function toContentPath(path: string | undefined | null): string {
+  const pathname = stripDocsBasePath(path || '/')
+  if (pathname === '/') {
+    return '/'
+  }
+  return pathname.replace(/\/+$/, '') || '/'
+}
+
+/**
+ * App-relative raw markdown URL. Must be built from the slashless content path;
+ * interpolating `/raw${route.path}.md` becomes `/raw/getting-started/.md`, which
+ * no longer ends in `/` so NuxtLink trailingSlash remove cannot repair it.
+ */
+export function toRawMarkdownPath(path: string | undefined | null): string {
+  return `/raw${toContentPath(path)}.md`
+}
+
 function isFilePath(path: string): boolean {
   const last = path.split('/').pop() || ''
   return last.includes('.')
@@ -122,7 +144,7 @@ export function isPublicDocsPath(path: string | undefined | null): boolean {
   if (!path) {
     return false
   }
-  const pathname = stripDocsBasePath(path)
+  const pathname = toContentPath(path)
   if (pathname === '/404' || pathname === '/404.html') {
     return false
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
SEO/AEO pass on the Nuxt docs site (GitHub Pages project host `https://madeyoga.github.io/AuthEndpoints/`). Does not change the C# library.

Verified locally with `NUXT_APP_BASE_URL=/AuthEndpoints/ pnpm generate` (lint + typecheck clean) and in-browser client navigation on the generated site. Live Pages will only update after merge to `main`.

## What changed

- **Sitemap:** prerender `/sitemap.xml` with trailing-slash locs on `https://madeyoga.github.io/AuthEndpoints/...` (home, changelog, docs pages, including the new compare and FAQ URLs below). Content `.navigation.yml` files are omitted. `<link rel="sitemap">` is on every page. Host-root `robots.txt` still belongs to the portfolio repo.
- **Canonical / og:url:** every page uses `https://madeyoga.github.io/AuthEndpoints/{path}/`.
- **Favicon:** `href` is resolved against `app.baseURL` → `/AuthEndpoints/favicon.svg`.
- **Home title:** `AuthEndpoints — ASP.NET Core Identity auth library`. Inner pages keep `%s - AuthEndpoints`.
- **Home one-liner:** `Ready-made auth endpoints on top of ASP.NET Core Identity, not a replacement. Cookies, JWT, and passkeys for first-party web and mobile apps.` (hero + `seo.description` + JSON-LD).
- **og:image:** `defineOgImage` on home and changelog. `site.url` is the github.io **origin** so images are `https://madeyoga.github.io/AuthEndpoints/_og/...` (not a doubled `/AuthEndpoints/AuthEndpoints/` path).
- **JSON-LD:** `SoftwareApplication` + `SoftwareSourceCode` on home; `TechArticle` on docs pages and changelog. No invented ratings or download counts.
- **nofollow:** drop `rel=nofollow` on this docs host, `github.com/madeyoga/AuthEndpoints`, and the NuGet package page (markdown `{rel="nofollow"}` came from default `rehype-external-links`). Unrelated externals still get nofollow. Changelog “External OAuth docs” links are in-app paths.
- **404:** GitHub Pages’ empty SPA `404.html` is replaced with a prerendered error page (title “Page not found”, body, Docs home). HTTP 404 is still GitHub Pages’ behavior for missing paths.
- **Nav trailing slashes:** `NuxtLink` `trailingSlash: 'append'` so sidebar/header hrefs match live `/path/` URLs.
- **Content lookup vs trailing slashes:** public hrefs stay `/getting-started/`, but docs collection queries, surroundings, and `/raw/*.md` URLs use slashless Content paths (`/getting-started`). View as Markdown / copy-page resolve under `app.baseURL` (`/AuthEndpoints/raw/getting-started.md`, not `/raw/getting-started/.md`).
- **Compare:** `/getting-started/compare/` — AuthEndpoints vs wiring Identity yourself, OpenIddict, and Identity API endpoints (`MapIdentityApi`).
- **FAQ:** `/getting-started/faq/` — Identity replacement, cookies vs JWT, passkeys, 2FA, composing routes, and Sign in with Google as a provider.

## New public URLs (after Pages deploy)

- `https://madeyoga.github.io/AuthEndpoints/getting-started/compare/`
- `https://madeyoga.github.io/AuthEndpoints/getting-started/faq/`

## Out of scope

Portfolio CTA copy and intro rewrite beyond the homepage one-liner. No new `/api` route. `src/` C# library untouched.

## What a Pages deploy still has to prove

This PR cannot update the live site (docs workflow deploys from `main`). After merge + Actions:

1. `https://madeyoga.github.io/AuthEndpoints/sitemap.xml` is `200` XML (not the SPA 404). Every `<loc>` is a trailing-slash URL under `https://madeyoga.github.io/AuthEndpoints/`. Includes `/getting-started/compare/` and `/getting-started/faq/`. No `.navigation` entries.
2. View-source (not DevTools after hydration) on `/`, `/getting-started/`, `/changelog/`, `/getting-started/compare/`, `/getting-started/faq/`:
   - canonical and `og:url` match the trailing-slash public URL
   - favicon is `/AuthEndpoints/favicon.svg` (and that URL is `200`)
   - JSON-LD `application/ld+json` is present (SoftwareApplication on home, TechArticle on inner pages)
   - home title is the longer phrase; home description is the new one-liner
3. In-app sidebar/header navigation to `/getting-started/` (and other docs pages) renders the page (not a client 404). “View as Markdown” / copy-page hits `/AuthEndpoints/raw/getting-started.md`, not `/raw/getting-started/.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37671383-958f-4c9f-8ef2-1f99e033733c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37671383-958f-4c9f-8ef2-1f99e033733c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

