### PR TITLE
Bump AuthEndpoints to 3.0.1

### DIFF
--- a/Documentation/content/versions/v3.0.0.md
+++ b/Documentation/content/versions/v3.0.0.md
@@ -2,7 +2,6 @@
 title: v3.0.0
 description: First stable 3.0 release — opinionated facade, cookie / bearer / JWT, passkeys, 2FA, and ReAuth on .NET 10.
 date: 2026-08-27
-badge: Latest
 tag: v3.0.0
 ---
 

--- a/Documentation/content/versions/v3.0.1.md
+++ b/Documentation/content/versions/v3.0.1.md
@@ -1,0 +1,25 @@
+---
+title: v3.0.1
+description: Passkey register and login honor CanSignInAsync / confirmed-account policy.
+date: 2026-08-29
+badge: Latest
+tag: v3.0.1
+---
+
+### AuthEndpoints
+
+Patch release on 3.0.0. Passkey register and login now call Identity `CanSignInAsync` before establishing a session or issuing tokens, so confirmed-account (and other Identity sign-in) policy matches password and OAuth.
+
+- Unconfirmed register still returns the new credential without a session
+- Unconfirmed login returns 401, same shape as Identity login
+
+### Packages
+
+- **AuthEndpoints** `3.0.1`
+- **AuthEndpoints.External.OAuth** unchanged at `3.0.0-preview.3`
+
+### Links
+
+- [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/v3.0.1)
+- [Compare](https://github.com/madeyoga/AuthEndpoints/compare/v3.0.0...v3.0.1)
+- [Installation](/getting-started/installation)

--- a/src/AuthEndpoints/AuthEndpoints.csproj
+++ b/src/AuthEndpoints/AuthEndpoints.csproj
@@ -6,14 +6,14 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Description>Auth library that provides a set of minimal api endpoints to handle authentication actions</Description>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Authors>madeyoga</Authors>
     <Company>madeyoga</Company>
     <PackageProjectUrl>https://github.com/madeyoga/AuthEndpoints</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/madeyoga/AuthEndpoints</RepositoryUrl>
     <PackageTags>auth;endpoints;aspnetcore;jwt;passkey;webauthn;2fa;identity</PackageTags>
-    <PackageReleaseNotes>AuthEndpoints 3.0: opinionated AddAuthEndpoints/UseAuthEndpoints/MapAuthEndpoints facade; cookie, Identity bearer, and Simple JWT sign-in; passkeys (WebAuthn) with pluggable IPasskeySignInCompleter; 2FA; ReAuth step-up; .NET 10.</PackageReleaseNotes>
+    <PackageReleaseNotes>Passkey register and login honor CanSignInAsync, so confirmed-account (and other Identity sign-in) policy matches password and OAuth.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Version bump + changelog for the CanSignInAsync passkey patch already on main.

- AuthEndpoints `3.0.0` → `3.0.1`
- Docs changelog `v3.0.1`; `v3.0.0` is no longer marked Latest
- AuthEndpoints.External.OAuth remains `3.0.0-preview.3`

Made will merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b959d74-6b61-41bd-8fb0-12d953dcdd6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b959d74-6b61-41bd-8fb0-12d953dcdd6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

