### PR TITLE
Align remaining 3.0 docs with LoginCookie and current APIs

### DIFF
--- a/Documentation/content/1.getting-started/2.installation.md
+++ b/Documentation/content/1.getting-started/2.installation.md
@@ -13,7 +13,7 @@ navigation:
 dotnet add package AuthEndpoints
 ```
 
-Exact versions are listed on [NuGet](https://www.nuget.org/packages/AuthEndpoints/) and in the [changelog](/changelog).
+Current stable is 3.0.1. Exact versions are listed on [NuGet](https://www.nuget.org/packages/AuthEndpoints/) and in the [changelog](/changelog).
 
 ## Requirements
 

--- a/Documentation/content/2.composables/2.requirements.md
+++ b/Documentation/content/2.composables/2.requirements.md
@@ -47,8 +47,8 @@ If you intentionally map management on two groups (for example cookie + bearer t
 
 - Cookie and other CSRF-sensitive endpoints use `RequireAntiforgery()` (endpoint filter).
 - Bearer JWT / Identity bearer: the filter **skips** CSRF when the request is authenticated via bearer schemes and **not** the application/external cookie.
-- Clients: `GET …/csrfToken` → send `RequestVerificationToken` on unsafe methods.
-- Optional host middleware: `AntiforgeryEnforcementMiddleware` (the Demo sample uses it; filter-only is enough for mapped endpoints).
+- Clients: send header `RequestVerificationToken` on endpoints that call `RequireAntiforgery()`. Cookie `POST /login` (`LoginCookie`) does **not**. Obtain the token from `GET …/csrfToken`.
+- Optional host middleware: `AntiforgeryEnforcementMiddleware` (this library). Filter-only is enough for mapped endpoints.
 
 ## 5. Rate-limit policies
 

--- a/Documentation/content/2.composables/3.recipes.md
+++ b/Documentation/content/2.composables/3.recipes.md
@@ -25,6 +25,10 @@ navigation:
 
 Passkeys are WebAuthn-oriented (browsers and platform passkey APIs). With the default Identity completer, register/login issue an **Identity bearer** token, or an application cookie when `?useCookies=true` / `?useSessionCookies=true`. For Simple JWT after passkey, register `JwtPasskeySignInCompleter` (see [Passkeys](/modules/passkeys#simple-jwt)) — do not call password JWT `/create` after a successful passkey.
 
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+`POST /identity/login?useCookies=true` does **nothing** under the facade. Facade password login maps `LoginCookie`, which ignores `useCookies`. That query only affects bearer `Login` (`MapBearerAuthEndpoints`) and the default passkey completer. Persistent cookie on facade password login: `?useSessionCookies=false`. See [Cookie auth](/modules/cookie-auth).
+::
+
 ## Advanced composition
 
 Compose modules yourself when you need bearer Identity, custom paths, or JWT-only. Map management **once** in production hosts.
@@ -100,7 +104,18 @@ Best for browser clients that want a Bearer access token with an HttpOnly refres
 
 ## Custom paths
 
-Prefixes are arbitrary as long as DI and middleware match. The Demo host uses paths such as `/auth/cookie`, `/auth/passkey`, and `/auth/jwt` via facade options.
+Prefixes are arbitrary as long as DI and middleware match. Set facade `IdentityPath`, `PasskeyPath`, and `Jwt.Path`:
+
+```cs
+builder.Services.AddAuthEndpoints<AppUser, AppDbContext>(o =>
+{
+    o.IdentityPath = "/auth/cookie";  // management + cookie login
+    o.PasskeyPath = "/auth/passkey";  // maps /auth/passkey/passkeys
+    o.Jwt.Path = "/auth/jwt";         // used when o.Jwt.Enabled = true
+});
+```
+
+For compose hosts, use `MapGroup("/your-prefix")` with the matching `Map*` methods.
 
 ## Related modules
 

--- a/Documentation/content/3.modules/1.identity-management.md
+++ b/Documentation/content/3.modules/1.identity-management.md
@@ -26,8 +26,8 @@ Relative to the group prefix (facade default `/identity`):
 | Method | Path | Notes |
 | --- | --- | --- |
 | `POST` | `/register` | Creates user; duplicate email returns `200 OK` (no enumeration). Rate-limited. |
-| `GET` | `/confirmEmail` | Confirms email via link token |
-| `POST` | `/resendConfirmationEmail` | Auth + CSRF + rate limit |
+| `GET` | `/confirmEmail` | Query `userId`, `code`, optional `changedEmail` |
+| `POST` | `/resendConfirmationEmail` | Auth + CSRF + rate limit. Signed-in user only; body `email` is ignored. |
 | `POST` | `/forgotPassword` | Rate-limited |
 | `POST` | `/resetPassword` | Rate-limited |
 | `GET` | `/manage/authMethods` | ReAuth methods (see [ReAuth](/modules/reauth)) |
@@ -37,6 +37,20 @@ Relative to the group prefix (facade default `/identity`):
 | `POST` | `/manage/2fa` | Enable/disable 2FA — CSRF + ReAuth |
 | `GET` | `/manage/info` | Current user info |
 | `POST` | `/manage/info` | Update info — CSRF + ReAuth |
+
+### confirmEmail
+
+Query string on `GET /confirmEmail`:
+
+| Query | Required | Notes |
+| --- | --- | --- |
+| `userId` | yes | Identity user id |
+| `code` | yes | Confirmation (or change-email) token from the emailed link |
+| `changedEmail` | no | When set, confirms a change to that email and updates the user name |
+
+### resendConfirmationEmail
+
+Requires a signed-in user (`RequireAuthorization` + CSRF). The request body `email` (`ResendConfirmationEmailRequest`) is ignored; the handler resends to the signed-in user's email.
 
 ## Authorization
 

--- a/Documentation/content/3.modules/4.jwt.md
+++ b/Documentation/content/3.modules/4.jwt.md
@@ -56,6 +56,21 @@ Relative to the group prefix (facade default `/auth`):
 | `POST` | `/logout` | CSRF; revokes refresh family |
 | `GET` | `/csrfToken` | For refresh/logout |
 
+### Create request body
+
+`SimpleJwtLoginRequest` on `POST /create`:
+
+- `email`
+- `password`
+- `twoFactorCode` (optional)
+- `twoFactorRecoveryCode` (optional)
+
+Success returns an access token (`SimpleJwtTokenResponse`) and sets the refresh cookie.
+
+### Two-factor
+
+When 2FA is enabled and neither code is provided, `POST /create` returns **401** with Problem details extension `requiresTwoFactor: true` (`detail`: "Two-factor authentication is required."). Retry the same request with `twoFactorCode` or `twoFactorRecoveryCode`.
+
 ## Refresh cookie
 
 | Property | Value |

--- a/Documentation/content/3.modules/5.passkeys.md
+++ b/Documentation/content/3.modules/5.passkeys.md
@@ -51,13 +51,24 @@ After a successful register/login ceremony, AuthEndpoints calls `IPasskeySignInC
 
 ### Default: Identity
 
-`IdentityPasskeySignInCompleter` honors the same query flags as Identity login:
+`IdentityPasskeySignInCompleter` honors the same query flags as Identity bearer `Login` (`MapBearerAuthEndpoints`):
 
 - `?useCookies=true` → persistent application cookie
 - `?useSessionCookies=true` → session application cookie
 - neither → Identity bearer token (`AccessTokenResponse`)
 
+::callout{icon="i-lucide-info"}
+The default completer follows bearer `Login` flags, **not** facade `LoginCookie`. `?useCookies=true` has no effect on `POST /identity/login` under `MapAuthEndpoints`. See [Cookie auth](/modules/cookie-auth).
+::
+
 Register also returns `PasskeyCredentialResponse` (credential id). Completers only establish a session when `CanSignInAsync` succeeds (same confirmed-account / lockout policy as Identity login and OAuth).
+
+When `CanSignInAsync` fails (unconfirmed account, lockout):
+
+| Kind | Identity completer | JWT completer |
+| --- | --- | --- |
+| Register | `PasskeyCredentialResponse` (credential id); **no** session | empty `200` |
+| Login | `401` Invalid credentials | `401` Invalid credentials |
 
 ### Simple JWT
 

--- a/Documentation/content/3.modules/7.external-oauth.md
+++ b/Documentation/content/3.modules/7.external-oauth.md
@@ -137,7 +137,9 @@ Relative to the group prefix (example `/auth/external`):
 
 Ensure the provider principal includes email + `email_verified` when `RequireVerifiedEmail` is true.
 
-## Configuration (Demo)
+## Configuration
+
+OAuth `ClientId` / `ClientSecret` come from host configuration (environment variables, user secrets, or a configuration provider). They are not `ExternalAuthOptions` properties. Typical environment variable names:
 
 | Variable | Provider |
 | --- | --- |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recipes, requirements, passkeys, JWT, identity management, external OAuth, and installation now match the 3.0 facade: LoginCookie vs Login flags, CSRF on login, confirmEmail query, JWT create/2FA, and current stable 3.0.1.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-624bb2bb-423c-455f-8282-2b69f0cbe8f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-624bb2bb-423c-455f-8282-2b69f0cbe8f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

