### PR TITLE
Document LoginCookie vs Login and CSRF on cookie login

### DIFF
--- a/Documentation/content/1.getting-started/4.quick-start.md
+++ b/Documentation/content/1.getting-started/4.quick-start.md
@@ -52,12 +52,30 @@ Your `DbContext` should be `IdentityDbContext<AppUser, AppRole, TKey>` (or equiv
 | Passkeys | `/account` | passkeys register/login options + complete, credential CRUD |
 | JWT (if enabled) | `/auth` | `create`, `refresh`, `verify`, `logout`, `csrfToken` |
 
+JWT is opt-in (`o.Jwt.Enabled = true`). Identity bearer is compose-only (`AddBearerAuthEndpoints` / `MapBearerAuthEndpoints`); the facade does not map bearer.
+
+## Facade password login
+
+`MapAuthEndpoints` maps `LoginCookie` to `POST /identity/login` (or your `IdentityPath`).
+
+| Query | Result |
+| --- | --- |
+| omitted | session application cookie |
+| `useSessionCookies=true` | session application cookie |
+| `useSessionCookies=false` | persistent application cookie |
+| `useCookies=true` | ignored |
+
+Persistent cookie: `POST /identity/login?useSessionCookies=false`.
+
+Passkeys use Identity `Login` flag rules (`useCookies` / `useSessionCookies`) unless `JwtPasskeySignInCompleter` is registered. See [Passkeys](/modules/passkeys) and [Cookie auth](/modules/cookie-auth).
+
 ## Client usage notes
 
 ### Cookie stack
 
 - Send cookies with credentials (`credentials: "include"` / Axios `withCredentials`).
-- Call `GET /identity/csrfToken`, then send the token as `RequestVerificationToken` on unsafe methods (`POST` / `PUT` / `PATCH` / `DELETE`).
+- `POST /identity/login` does not require CSRF.
+- Call `GET /identity/csrfToken`, then send the token as `RequestVerificationToken` on logout, manage mutations, and other CSRF-protected unsafe methods (`POST` / `PUT` / `PATCH` / `DELETE`).
 
 ### JWT stack (when enabled)
 

--- a/Documentation/content/3.modules/2.cookie-auth.md
+++ b/Documentation/content/3.modules/2.cookie-auth.md
@@ -7,6 +7,8 @@ navigation:
 
 Cookie sign-in for first-party web/browser clients. Pair with [Identity management](/modules/identity-management).
 
+`MapCookieAuthEndpoints` (and the facade `MapAuthEndpoints`) maps `LoginCookie` to `POST {prefix}/login`. The scheme is always `IdentityConstants.ApplicationScheme`.
+
 ## DI
 
 ```cs
@@ -14,11 +16,15 @@ builder.Services.AddAntiforgery();
 builder.Services.AddCookieAuthEndpoints(); // ReAuth schemes + rate limits
 ```
 
+The facade (`AddAuthEndpoints`) registers these for you.
+
 ## Map
 
 ```cs
 app.MapGroup("/identity").MapCookieAuthEndpoints<AppUser>();
 ```
+
+The facade maps this group under `IdentityPath` (default `/identity`).
 
 ## Routes
 
@@ -26,30 +32,54 @@ Relative to the group prefix (facade default `/identity`):
 
 | Method | Path | Notes |
 | --- | --- | --- |
-| `POST` | `/login` | Application cookie; lockout on failure; rate-limited |
+| `POST` | `/login` | `LoginCookie`; application cookie; lockout on failure; rate-limited |
 | `POST` | `/logout` | Auth + CSRF |
 | `GET` | `/csrfToken` | Antiforgery token for unsafe methods |
 
+## Login query string
+
+`LoginCookie` reads **only** `useSessionCookies`. `useCookies` is ignored.
+
+| Query | Result |
+| --- | --- |
+| omitted | session application cookie |
+| `useSessionCookies=true` | session application cookie |
+| `useSessionCookies=false` | persistent application cookie |
+| `useCookies=true` | ignored |
+
+Persistent cookie: `POST /identity/login?useSessionCookies=false`.
+
+Passkey register/login uses a different flag table. See [Passkeys](/modules/passkeys).
+
 ## Login body
 
-Uses Identity login fields, including optional:
+Identity `LoginRequest`:
 
-- `twoFactorCode`
-- `twoFactorRecoveryCode`
+- `email`
+- `password`
+- `twoFactorCode` (optional)
+- `twoFactorRecoveryCode` (optional)
+
+## CSRF
+
+`POST /login` does **not** require antiforgery. `POST /logout` and cookie-authenticated unsafe methods (`POST` / `PUT` / `PATCH` / `DELETE` on CSRF-protected routes) do.
 
 ## Client notes
 
 1. Send cookies: `credentials: "include"` (or Axios `withCredentials: true`).
-2. `GET /identity/csrfToken` (or your prefix).
-3. On `POST` / `PUT` / `PATCH` / `DELETE`, send header `RequestVerificationToken` with the token value.
+2. `POST /login` does not require CSRF.
+3. Before logout and other CSRF-protected unsafe methods, call `GET /identity/csrfToken` (or your prefix) and send header `RequestVerificationToken` with the token value.
 
 ## Gotchas
 
 - Pipeline must include authentication, authorization, rate limiting, and antiforgery.
 - Do not map cookie and bearer login on the same path without separate groups — pick one sign-in stack per prefix.
 - CORS must allow credentials if the web client origin differs from the API.
+- Do not confuse `LoginCookie` with bearer `Login` (`MapBearerAuthEndpoints`).
 
 ## Related
 
 - [Identity management](/modules/identity-management)
+- [Passkeys](/modules/passkeys)
+- [Bearer auth](/modules/bearer-auth)
 - [Composable recipes](/composables/recipes)

--- a/Documentation/content/3.modules/3.bearer-auth.md
+++ b/Documentation/content/3.modules/3.bearer-auth.md
@@ -7,6 +7,8 @@ navigation:
 
 ASP.NET Core Identity **bearer token** sign-in (not JWT). Pair with [Identity management](/modules/identity-management).
 
+This module maps Identity `Login`. The facade does **not** map these routes — compose `AddBearerAuthEndpoints` and `MapBearerAuthEndpoints`.
+
 ## When to choose bearer vs JWT
 
 | Stack | Use when |
@@ -30,13 +32,25 @@ app.MapGroup("/identity").MapBearerAuthEndpoints<AppUser>();
 
 | Method | Path | Notes |
 | --- | --- | --- |
-| `POST` | `/login` | Issues Identity bearer tokens (`AccessTokenResponse`); rate-limited |
+| `POST` | `/login` | `Login`; Identity bearer tokens (`AccessTokenResponse`) when both query flags are omitted; rate-limited |
 | `POST` | `/refresh` | Refresh access token |
 | `POST` | `/logout` | Requires authorization |
 
-## Scheme selection on login
+## Login query string
 
-The shared Identity login handler also supports cookie selection query flags used by passkey flows (`useCookies` / `useSessionCookies`). For a pure bearer stack, omit those flags so Identity bearer tokens are issued.
+Issues an application cookie when `useCookies` or `useSessionCookies` is true. Persistent when `useCookies` is true and `useSessionCookies` is not true. Neither flag → Identity bearer tokens (`AccessTokenResponse`).
+
+| Query | Result |
+| --- | --- |
+| neither flag | Identity bearer tokens |
+| `useCookies=true` (and `useSessionCookies` not true) | persistent application cookie |
+| `useSessionCookies=true` | session application cookie |
+
+These flags apply to `Login` and to the default passkey completer. They do **not** apply to facade / `LoginCookie` password login. See [Cookie auth](/modules/cookie-auth) and [Passkeys](/modules/passkeys).
+
+## Logout
+
+`POST /logout` requires authorization. It signs out cookies only and does **not** revoke Identity bearer tokens. Tokens remain valid until they expire.
 
 ## Antiforgery
 
@@ -44,5 +58,6 @@ Bearer-authenticated requests typically skip CSRF when not using the application
 
 ## Related
 
+- [Cookie auth](/modules/cookie-auth)
 - [JWT module](/modules/jwt) for JWT
 - [Composable recipes](/composables/recipes)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cookie and bearer pages now name LoginCookie vs Login, document query flags, and state that POST /login does not require CSRF. Quick start matches.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac2c3fc8-2e61-4535-ba97-3d63e3badcd4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac2c3fc8-2e61-4535-ba97-3d63e3badcd4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

