### PR TITLE
Document the agent skill and drop product name from Compare and FAQ titles

### DIFF
--- a/Documentation/content/1.getting-started/1.index.md
+++ b/Documentation/content/1.getting-started/1.index.md
@@ -48,5 +48,5 @@ See [Quick start](/getting-started/quick-start) for the facade, and [Composable 
 
 ## Next
 
-- [AuthEndpoints compared](/getting-started/compare) — Identity yourself, OpenIddict, and `MapIdentityApi`
+- [Compare](/getting-started/compare) — Identity yourself, OpenIddict, and `MapIdentityApi`
 - [FAQ](/getting-started/faq)

--- a/Documentation/content/1.getting-started/3.ai-agents.md
+++ b/Documentation/content/1.getting-started/3.ai-agents.md
@@ -1,28 +1,24 @@
 ---
 title: AI agents
-description: Load the AuthEndpoints skill in Cursor or another coding agent.
+description: Install the AuthEndpoints skill for Cursor and other coding agents.
 navigation:
   icon: i-lucide-bot
 ---
 
-The library installs with NuGet. The skill is extra, for coding agents.
+The skill is for coding agents. Install the NuGet package separately.
 
 ```bash
 npx skills add madeyoga/AuthEndpoints
 ```
 
-That command pulls `skills/authendpoints/` from [madeyoga/AuthEndpoints](https://github.com/madeyoga/AuthEndpoints) into the current project. Most agents put it in `.agents/skills` or `.cursor/skills`.
-
-Install the package as usual:
+This copies `skills/authendpoints/` into the project, typically `.agents/skills` or `.cursor/skills`.
 
 ```bash
 dotnet add package AuthEndpoints
 ```
 
-Current stable is 3.0.1. Configuration, modules, and production notes live at https://madeyoga.github.io/AuthEndpoints. There is no MCP server.
+Current stable is 3.0.1. See [Installation](/getting-started/installation) and [Quick start](/getting-started/quick-start).
 
-### This repository
+## This repository
 
-When AuthEndpoints itself is the Cursor workspace, Cursor loads `.cursor/skills/authendpoints/`. It does not auto-load `skills/` at the repo root.
-
-Optional: in Cursor, Customize → Rules → Remote Rule (GitHub), and paste `https://github.com/madeyoga/AuthEndpoints`.
+If this repository is the Cursor workspace, Cursor loads `.cursor/skills/authendpoints/`. It does not load `skills/` at the repo root. To attach the skill as a Cursor remote rule, add GitHub repo `https://github.com/madeyoga/AuthEndpoints`.

--- a/Documentation/content/1.getting-started/7.compare.md
+++ b/Documentation/content/1.getting-started/7.compare.md
@@ -1,5 +1,5 @@
 ---
-title: AuthEndpoints compared
+title: Compare
 description: How AuthEndpoints differs from wiring ASP.NET Core Identity yourself, from OpenIddict, and from Identity API endpoints.
 navigation:
   icon: i-lucide-git-compare

--- a/Documentation/content/1.getting-started/8.faq.md
+++ b/Documentation/content/1.getting-started/8.faq.md
@@ -1,5 +1,5 @@
 ---
-title: AuthEndpoints FAQ
+title: FAQ
 description: Does AuthEndpoints replace Identity? Cookie or JWT? Passkeys, 2FA, composing routes, and Sign in with Google as a provider.
 navigation:
   icon: i-lucide-circle-help
@@ -35,7 +35,7 @@ No. Optional GitHub and Google login into your app is `AuthEndpoints.External.OA
 
 ## Related
 
-- [AuthEndpoints compared](/getting-started/compare)
+- [Compare](/getting-started/compare)
 - [Quick start](/getting-started/quick-start)
 - [Composable endpoints](/composables)
 - [Passkeys](/modules/passkeys)

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ For configuration, composable modules, route tables, and production guidance, se
 
 ## AI agents
 
+Add the coding-agent skill from this repository:
+
 ```bash
 npx skills add madeyoga/AuthEndpoints
 ```
 
-That installs the skill from `skills/authendpoints/` in this repository. Agents copy it into the project, usually `.agents/skills` or `.cursor/skills`. It does not add the NuGet package. Use `dotnet add package AuthEndpoints` (3.0.1) for that. Docs stay at https://madeyoga.github.io/AuthEndpoints. There is no MCP server.
-
-If you have this repository open in Cursor, `.cursor/skills/authendpoints/` loads automatically. Cursor does not load the root `skills/` folder. Optional: Customize → Rules → Remote Rule (GitHub), repo URL `https://github.com/madeyoga/AuthEndpoints`.
+This does not install the NuGet package. Add that with `dotnet add package AuthEndpoints`. See [AI agents](https://madeyoga.github.io/AuthEndpoints/getting-started/ai-agents/).
 
 ## Contribute
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents the coding-agent skill (`npx skills add madeyoga/AuthEndpoints`) in the README and getting-started AI agents page, separate from the NuGet package. Shortens Compare and FAQ titles, and matching intro/FAQ links, by dropping the product name.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6764646d-8c2c-4e24-bf52-94519f578a6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6764646d-8c2c-4e24-bf52-94519f578a6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

