### PR TITLE
Fix invalid ports schema in .cursor/environment.json

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -7,5 +7,5 @@
       "command": "export DOTNET_ROOT=\"$HOME/.dotnet\"; export PATH=\"$HOME/.dotnet:$PATH\"; export ASPNETCORE_ENVIRONMENT=Development; dotnet run --project tests/AuthEndpoints.Tests --urls http://0.0.0.0:5080"
     }
   ],
-  "ports": [5080]
+  "ports": [{ "name": "demo-api", "port": 5080 }]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`.cursor/environment.json` (added in #243) declares `ports` as a list of bare numbers:

```jsonc
"ports": [5080]
```

The Cloud Agent environment schema requires each `ports` entry to be an **object** with a required `port` field, so this fails validation:

```
[ { "code": "invalid_type", "expected": "object", "received": "number",
    "path": [ "ports", 0 ], "message": "Expected object, received number" } ]
```

## Fix

Use the schema-compliant object form:

```jsonc
"ports": [{ "name": "demo-api", "port": 5080 }]
```

## Validation

- `.cursor/environment.json` parses as valid JSON.
- Validated against the live schema at `https://cursor.com/schemas/environment.schema.json` — `ports` items must be objects with a required integer `port` (1–65535) and optional `name`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44829a46-0e45-4217-b34e-5d01f970a511?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44829a46-0e45-4217-b34e-5d01f970a511&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

