### PR TITLE
Poteto-mode: Add verify-authendpoints skill for live HTTP API checks

### DIFF
--- a/.cursor/skills/verify-authendpoints/SKILL.md
+++ b/.cursor/skills/verify-authendpoints/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: verify-authendpoints
+description: Drive the AuthEndpoints HTTP API via the in-repo test host (cookie sessions, Identity bearer, Simple JWT, CSRF, ReAuth). Use when verifying a change to src/AuthEndpoints or tests/AuthEndpoints.Tests, proving register/login/session/token behavior, or when a task needs a live auth API instead of only `dotnet test`.
+---
+
+# Verify AuthEndpoints
+
+AuthEndpoints is a **library**, not a GUI app. The user-facing surface to drive is the **HTTP API** composed by the in-repo test host in `tests/AuthEndpoints.Tests/Program.cs`. A later agent that has never seen the repo should launch that host, call the same routes a first-party client would, and keep response files as proof.
+
+xUnit under `tests/AuthEndpoints.Tests` is complementary regression coverage. It does **not** replace this skill. Do not treat `dotnet test` as evidence that a live cookie/CSRF/token path works.
+
+The Nuxt docs site in `Documentation/` is a separate surface. Do not use this skill to verify docs UI.
+
+## Launch
+
+Preconditions:
+
+- .NET **10** SDK on `PATH` (`dotnet --version` starts with `10.`).
+- Run from the repository root.
+- Pick a unique `AE_RUN_ID` and a free `AE_PORT`. Do not attach to an already-running host.
+
+```bash
+export PATH="$HOME/.dotnet:$PATH"   # if the SDK was installed with dotnet-install.sh
+export AE_RUN_ID="${AE_RUN_ID:-$(date +%Y%m%dT%H%M%S)-$$}"
+export AE_PORT="${AE_PORT:-5088}"
+export AE_EVIDENCE_DIR="${AE_EVIDENCE_DIR:-/tmp/authendpoints-verify-${AE_RUN_ID}/evidence}"
+HARNESS=".cursor/skills/verify-authendpoints/scripts/ae-http.sh"
+
+chmod +x "$HARNESS"
+"$HARNESS" launch
+"$HARNESS" doctor
+```
+
+Ready signal: `GET {AE_BASE_URL}/identity/csrfToken` returns **200** and JSON with `csrfToken` (Pascal `CsrfToken` is also accepted). The helper polls that URL after start.
+
+Teardown: `"$HARNESS" stop` kills **only** the PID in `$AE_RUN_DIR/host.pid`. It must not delete `$AE_EVIDENCE_DIR`.
+
+What the host actually is (`tests/AuthEndpoints.Tests/Program.cs`):
+
+| Prefix | Mapped surface |
+| --- | --- |
+| `/identity` | Identity management + **cookie** login (`LoginCookie`) + logout + `/csrfToken` |
+| `/identity/bearer` | Second management map + **Identity bearer** login (`Login`) |
+| `/auth` | Simple JWT (`/create`, `/refresh`, `/verify`, `/logout`, `/csrfToken`) |
+| `/account` | Passkey routes |
+| `/test/*` | **Test-only** probes (`/test/csrf`, `/test/reauth`, `/test/csrf-auth`). Not library surface. Use them only as extra observation, never as the sole proof of a library feature. |
+
+Host defaults that **differ from production library defaults**:
+
+- `SignIn.RequireConfirmedAccount = false` (library facade default is **true**).
+- Password rules are relaxed (`RequiredLength = 6`, no digit/case/symbol requirements). Use `Passw0rd!`.
+- EF Core **in-memory** database; all users vanish when the process exits.
+- JWT signing key is the test-only value in `Program.cs`. Never treat it as a production secret.
+
+Isolation: two hosts may run on **different ports**. Refuse to drive a port that was already listening when `launch` ran. Never kill by process name (`pkill`, `killall`).
+
+## Doctor
+
+Run `"$HARNESS" doctor` before the first drive, after any failed drive, and whenever the host looks wrong. It is read-only and must report:
+
+1. `$AE_RUN_DIR/host.pid` exists and that PID is alive.
+2. `AE_BASE_URL` accepts connections (the port we chose).
+3. `GET /identity/csrfToken` is 200 with a non-empty `csrfToken`.
+
+If doctor fails, `stop` (if we started the process) and `launch` again. Do not keep driving a surprising instance.
+
+## Drive
+
+Use the harness. It wraps curl with a cookie jar, retries **429** (login is a token bucket: 10 tokens, +2 / 10s), and can attach CSRF, `Authorization: Bearer`, and `X-AuthEndpoints-Reauth`.
+
+```bash
+HARNESS=".cursor/skills/verify-authendpoints/scripts/ae-http.sh"
+EMAIL="verify-${AE_RUN_ID}@test.local"
+PASS='Passw0rd!'
+
+"$HARNESS" post /identity/register "{\"email\":\"${EMAIL}\",\"password\":\"${PASS}\"}" --out register
+"$HARNESS" post /identity/login "{\"email\":\"${EMAIL}\",\"password\":\"${PASS}\"}" --out login
+"$HARNESS" get /identity/manage/info --out info
+"$HARNESS" post --csrf /identity/logout --out logout
+```
+
+Stable handles (paths and headers), not coordinates:
+
+| Handle | Value |
+| --- | --- |
+| Cookie login | `POST /identity/login` JSON `{email,password}`. Query `useCookies` is **ignored**. Only `useSessionCookies=false` makes the cookie persistent. |
+| Bearer login | `POST /identity/bearer/login` with **no** cookie flags → JSON `accessToken` + `refreshToken`. `?useCookies=true` issues the application cookie instead. |
+| JWT login | `POST /auth/create` JSON `{email,password}` → JSON `accessToken`; refresh is cookie `AuthEndpoints.Jwt.RefreshToken`. |
+| CSRF fetch | `GET /identity/csrfToken` or `GET /auth/csrfToken` |
+| CSRF header | `RequestVerificationToken` (ASP.NET Core default; the library does not rename it) |
+| ReAuth header | `X-AuthEndpoints-Reauth` with `reauthToken` from `POST /identity/confirmIdentity` |
+| Session cookie | `.AspNetCore.Identity.Application` |
+| JWT refresh cookie | `AuthEndpoints.Jwt.RefreshToken` |
+| ReAuth cookie | `AuthEndpoints.ReAuth` |
+
+Read the feature map before driving. Cover the mapped entry points for the feature you claim, not a single convenient alias.
+
+`AE_BEARER` and `AE_REAUTH` are honored by the helper on every request when set:
+
+```bash
+export AE_BEARER='...'    # Identity bearer or JWT access token
+export AE_REAUTH='...'    # reauthToken from confirmIdentity
+```
+
+## Evidence
+
+Default location: `$AE_EVIDENCE_DIR` (default `/tmp/authendpoints-verify-$AE_RUN_ID/evidence`). `stop` must leave this directory in place.
+
+Each drive step that uses `--out NAME` writes:
+
+- `NAME.request` — method, URL, body
+- `NAME.status` — HTTP status code
+- `NAME.headers` — response headers (cookies, WWW-Authenticate)
+- `NAME.body` — response body
+
+Proof standards:
+
+- Hit the **real client paths** in the table above, not `/test/*` as the only check, and not `WebApplicationFactory` internals.
+- Capture the **action and the resulting state**. Example: login headers (`Set-Cookie`) **and** a later `GET /identity/manage/info` (200 + email), not only the login status.
+- For mutations, prove a second read: after register+login, `manage/info`; after logout, `manage/info` is 401; after JWT create, `GET /auth/verify` with `Authorization: Bearer` is **204**.
+- 429 is not success. Retry via the helper; if still 429, wait 10s and retry the step. Do not record a rate-limit as a product failure unless it persists on a fresh host.
+- Duplicate register emails return **200** (no enumeration). Do not treat that 200 as “a second user was created” without a distinct email.
+
+Cloud Agent walkthroughs may **copy** evidence files to `/opt/cursor/artifacts` after the drive. Copying is extra; the named evidence dir is the source of truth.
+
+## Cleanup
+
+```bash
+"$HARNESS" stop
+```
+
+Removes the host process started by this run. Does **not** delete `$AE_EVIDENCE_DIR`. Cookie jar and host log under `$AE_RUN_DIR` may be left; they are scratch. After a failed iteration, still `stop` so the port is free.
+
+Never `pkill -f AuthEndpoints` or similar.
+
+## Helpers
+
+```bash
+.cursor/skills/verify-authendpoints/scripts/ae-http.sh --help
+```
+
+| Command | What it does |
+| --- | --- |
+| `launch` | `dotnet build` the test project, start `AuthEndpoints.Tests.dll` on `AE_BASE_URL`, wait until `/identity/csrfToken` is 200 |
+| `doctor` | PID + port + csrfToken |
+| `csrf [path]` | Print the token string |
+| `get <path> [--out N]` | GET with cookie jar |
+| `post [--csrf] <path> [json] [--out N]` | POST JSON; `--csrf` fetches a token first (JWT paths use `/auth/csrfToken`) |
+| `stop` | SIGTERM the launch PID |
+
+The script is executable (`chmod +x` if git lost the bit).
+
+## Feature map
+
+Index: `.cursor/skills/verify-authendpoints/features/README.md`
+
+Start with those files. Automated `dotnet test AuthEndpoints.sln` is allowed **in addition** after a live drive, not instead of it.
+
+Passkeys (`/account/passkeys`) need a WebAuthn authenticator for a full ceremony. Do not claim passkey register/login verified from HTTP options JSON alone. Use the xUnit passkey tests for that path.
+
+## Maintenance
+
+When the host mappings, CSRF header, or login query flags change, update this skill and the feature map. `/maintain-verification-skill` is the upkeep loop.

--- a/.cursor/skills/verify-authendpoints/features/README.md
+++ b/.cursor/skills/verify-authendpoints/features/README.md
@@ -1,0 +1,47 @@
+# AuthEndpoints verification map
+
+This directory is the maintained source for verifying the HTTP API the library exposes through the in-repo test host. Read this index before driving, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Launch the test host with `.cursor/skills/verify-authendpoints/scripts/ae-http.sh launch`.
+- `ae-http.sh doctor` reports `ok` for this run’s PID and `AE_BASE_URL`.
+- Cookie jar is empty at the start of a feature unless that feature’s preconditions say otherwise.
+- Password for new users is `Passw0rd!`. Emails must be unique per run (`verify-<id>@test.local`).
+- Never drive a host this run did not start.
+- This host has `RequireConfirmedAccount = false`. That is a **test-host** setting, not the library facade default.
+
+## Driving conventions
+
+- Start every recipe from the baseline (fresh jar, doctor ok) unless listed otherwise.
+- Treat paths, JSON field names, and header names as literal.
+- Send JSON as `application/json`. Use `--csrf` only on unsafe cookie or JWT-cookie mutations that the map marks as CSRF-protected.
+- Login cookie route ignores `useCookies`. Bearer login does not.
+- On 429, let the helper retry. Do not hammer `/identity/login` or `/auth/create`.
+- Restore nothing in the database (in-memory). Start a new email or a new host if state is dirty.
+- Do not delete proof files during cleanup.
+
+## Proof and skip reporting
+
+- Capture the request, status, headers, and body for each step (`--out`).
+- Mutation proof includes a later GET (or a failed GET after logout).
+- Record the feature ID and the exact path used.
+- If an entry point cannot be reached, report the command and the unmet precondition. Do not mark it verified via a different path.
+- `/test/*` routes are not library entry points.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every client entry point.
+3. `Driving it with ae-http` starts with `Preconditions:` and pairs each action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a run.
+
+## Features
+
+- [Cookie session](./cookie-session.md) covers register, cookie login, session info, and logout.
+- [CSRF on cookie mutations](./csrf.md) covers token issue and the requirement on cookie logout.
+- [Identity bearer](./identity-bearer.md) covers token login, refresh, and the `useCookies` query flag.
+- [Simple JWT](./simple-jwt.md) covers `/auth/create`, verify, and refresh-cookie refresh.
+- [ReAuth step-up](./reauth.md) covers `confirmIdentity` and a protected manage mutation.

--- a/.cursor/skills/verify-authendpoints/features/cookie-session.md
+++ b/.cursor/skills/verify-authendpoints/features/cookie-session.md
@@ -1,0 +1,46 @@
+# Cookie session
+
+A first-party browser client registers with email and password, signs in through the cookie login handler, reads account info with the application cookie, and signs out.
+
+## Sub-features
+
+- `register-ok` creates an account at `POST /identity/register` and returns 200.
+- `register-invalid` rejects a non-email with 400.
+- `register-duplicate` returns 200 for a duplicate email (no second account signal).
+- `login-ok` signs in at `POST /identity/login` and sets `.AspNetCore.Identity.Application`.
+- `login-bad` returns 401 with `Invalid credentials` for a wrong password.
+- `info-session` returns 200 and the same email from `GET /identity/manage/info` after login.
+- `logout-session` clears the session so a later info GET is 401.
+
+## How to get to it (user POV)
+
+- `POST /identity/register` with JSON `{ "email", "password" }`.
+- `POST /identity/login` with the same JSON. Optional query `useSessionCookies=false` for a persistent cookie. `useCookies` is ignored on this handler.
+- `GET /identity/manage/info` with the application cookie.
+- `POST /identity/logout` with the application cookie and CSRF header.
+
+## Driving it with ae-http
+
+Preconditions:
+
+- Host is healthy (`ae-http.sh doctor`).
+- Cookie jar is empty.
+- `EMAIL` is unused on this host. `PASS` is `Passw0rd!`.
+
+- **Register.** Create the account. Run `ae-http.sh post /identity/register "{\"email\":\"${EMAIL}\",\"password\":\"${PASS}\"}" --out register`. Status is `200`. Body is empty or `{}`.
+- **Invalid email.** Register `not-an-email`. Run `ae-http.sh post /identity/register '{"email":"not-an-email","password":"Passw0rd!"}' --out register-invalid`. Status is `400`.
+- **Login.** Sign in. Run `ae-http.sh post /identity/login "{\"email\":\"${EMAIL}\",\"password\":\"${PASS}\"}" --out login`. Status is `200` or `204`. Headers include `Set-Cookie` for `.AspNetCore.Identity.Application`.
+- **Wrong password.** Use a distinct email that was registered, then login with `WrongPass1!`. Status is `401`. Body contains `Invalid credentials` and does not contain `LockedOut`.
+- **Session info.** Read the signed-in account. Run `ae-http.sh get /identity/manage/info --out info`. Status is `200`. Body `email` matches `EMAIL`.
+- **Logout.** End the session. Run `ae-http.sh post --csrf /identity/logout --out logout`. Status is `200` or `204`.
+- **Logged out.** Read info again. Run `ae-http.sh get /identity/manage/info --out info-after-logout`. Status is `401`.
+- **Proof.** Keep `register.*`, `login.headers` (cookie), `info.body` (email), and `info-after-logout.status` (`401`).
+
+## Gotchas
+
+- This path is `LoginCookie` on `/identity/login`. `useCookies=true` does nothing here. Persistent vs session is only `useSessionCookies=false` vs omitted/true.
+- Register does not sign the user in. Always login after register before calling `/manage/info`.
+- Duplicate email register is 200 by design. Use a new email when you need a distinct user.
+- Login is rate-limited (token bucket). Bursting logins from one IP yields 429.
+- Logout without CSRF is a CSRF failure, not a successful logout. See [CSRF on cookie mutations](./csrf.md).
+- Test host allows unconfirmed users to sign in. Production facade default does not.

--- a/.cursor/skills/verify-authendpoints/features/csrf.md
+++ b/.cursor/skills/verify-authendpoints/features/csrf.md
@@ -1,0 +1,40 @@
+# CSRF on cookie mutations
+
+Cookie clients must fetch an antiforgery token and send it on unsafe methods that mutate the cookie session. Token-only bearer requests skip that filter; a cookie session still requires CSRF even if a bearer token is also present.
+
+## Sub-features
+
+- `csrf-issue` returns a non-empty token from `GET /identity/csrfToken`.
+- `logout-missing-csrf` rejects cookie logout without the header.
+- `logout-with-csrf` succeeds when the header matches the antiforgery cookie in the jar.
+- `jwt-csrf-issue` returns a token from `GET /auth/csrfToken` for JWT refresh/logout.
+
+## How to get to it (user POV)
+
+- `GET /identity/csrfToken` (cookie prefix) or `GET /auth/csrfToken` (JWT prefix).
+- On `POST` / `PUT` / `PATCH` / `DELETE` that require antiforgery, send header `RequestVerificationToken` with that value **and** the cookies from the same jar.
+- Cookie logout: `POST /identity/logout`.
+- JWT refresh/logout: `POST /auth/refresh` and `POST /auth/logout` (JWT CSRF path).
+
+## Driving it with ae-http
+
+Preconditions:
+
+- Host is healthy.
+- A cookie session exists (register + `POST /identity/login` for `EMAIL`).
+- Cookie jar still holds the application cookie and the antiforgery cookie from `csrfToken`.
+
+- **Issue token.** Fetch CSRF. Run `ae-http.sh get /identity/csrfToken --out csrf`. Status is `200`. Body has `csrfToken`. Response sets an antiforgery cookie.
+- **Logout without header.** POST logout with the session cookie and no CSRF. Run `ae-http.sh post /identity/logout --out logout-no-csrf`. Status is **not** 200/204 (typically 400) and the body mentions CSRF. A following `GET /identity/manage/info` is still **200** (session remains).
+- **Logout with header.** POST logout through the harness CSRF helper. Run `ae-http.sh post --csrf /identity/logout --out logout-csrf`. Status is `200` or `204`.
+- **Session gone.** Run `ae-http.sh get /identity/manage/info --out info-after-csrf-logout`. Status is `401`.
+- **JWT CSRF endpoint.** Run `ae-http.sh get /auth/csrfToken --out jwt-csrf`. Status is `200` with `csrfToken`.
+- **Proof.** Keep `csrf.body` (token), `logout-no-csrf.status` (failure) plus `info` still 200, then `logout-csrf.status` and `info-after-csrf-logout.status` (`401`).
+
+## Gotchas
+
+- The header name is `RequestVerificationToken`. Hosts may rename it via `AntiforgeryOptions.HeaderName`; this test host does not.
+- The token is bound to the antiforgery **cookie**. A token from a different jar fails.
+- `--csrf` on JWT paths (`/auth/...`) uses `GET /auth/csrfToken`, not `/identity/csrfToken`.
+- Identity bearer login JSON and `POST /identity/bearer/refresh` are not cookie mutations. Do not require CSRF there. Cookie session + same request still needs CSRF.
+- `/test/csrf` is a test-only probe. It can illustrate an anonymous 400, but it is not a library route. Do not cite it as the only CSRF proof.

--- a/.cursor/skills/verify-authendpoints/features/identity-bearer.md
+++ b/.cursor/skills/verify-authendpoints/features/identity-bearer.md
@@ -1,0 +1,41 @@
+# Identity bearer
+
+A native or mobile client signs in at the bearer-mapped prefix and receives JSON access and refresh tokens. The same handler can issue an application cookie instead when cookie query flags are set.
+
+## Sub-features
+
+- `bearer-login` returns `accessToken` and `refreshToken` from `POST /identity/bearer/login` with no cookie flags.
+- `bearer-refresh` returns new tokens from `POST /identity/bearer/refresh`.
+- `bearer-refresh-bad` returns 401 for a garbage refresh token.
+- `bearer-use-cookies` with `?useCookies=true` signs in with the application cookie and does not require JSON tokens for `GET /identity/bearer/manage/info`.
+
+## How to get to it (user POV)
+
+- Register once at `POST /identity/register` (shared management on `/identity`).
+- `POST /identity/bearer/login` JSON `{ "email", "password" }` with neither `useCookies` nor `useSessionCookies` → tokens.
+- `POST /identity/bearer/login?useCookies=true` → application cookie (persistent unless `useSessionCookies=true`).
+- `POST /identity/bearer/login?useSessionCookies=true` → session application cookie.
+- `POST /identity/bearer/refresh` JSON `{ "refreshToken" }`.
+- `GET /identity/bearer/manage/info` with `Authorization: Bearer <accessToken>` or with the cookie from `useCookies`.
+
+## Driving it with ae-http
+
+Preconditions:
+
+- Host is healthy.
+- User `EMAIL` exists (register on `/identity/register` first). Use a fresh cookie jar so leftover application cookies do not confuse token vs cookie mode.
+
+- **Token login.** Run `ae-http.sh post /identity/bearer/login "{\"email\":\"${EMAIL}\",\"password\":\"${PASS}\"}" --out bearer-login`. Status is `200`. Body has `accessToken` and `refreshToken`.
+- **Manage with bearer.** Export `AE_BEARER` to that access token. Run `ae-http.sh get /identity/bearer/manage/info --out bearer-info`. Status is `200`. `email` matches `EMAIL`.
+- **Refresh.** Run `ae-http.sh post /identity/bearer/refresh "{\"refreshToken\":\"${REFRESH}\"}" --out bearer-refresh`. Status is `200`. Body has a new `accessToken`.
+- **Bad refresh.** Run `ae-http.sh post /identity/bearer/refresh '{"refreshToken":"not-a-real-refresh-token"}' --out bearer-refresh-bad`. Status is `401`.
+- **Cookie flag.** New jar. Run `ae-http.sh post "/identity/bearer/login?useCookies=true" "{\"email\":\"${EMAIL}\",\"password\":\"${PASS}\"}" --out bearer-cookie`. Status is `200` or `204`. Then `ae-http.sh get /identity/bearer/manage/info --out bearer-cookie-info` is `200` **without** `AE_BEARER`.
+- **Proof.** Keep `bearer-login.body` (both tokens), `bearer-info.body` (email), `bearer-refresh.body` (new access token), and `bearer-cookie-info.status` (`200`).
+
+## Gotchas
+
+- Facade cookie login (`/identity/login`) is a different handler. `useCookies` only applies to **this** Identity `Login` mapping.
+- Do not map cookie and bearer login on the same path in a real host. The test host uses `/identity` vs `/identity/bearer`.
+- Unset `AE_BEARER` before proving the cookie-flag path.
+- `/identity/bearer` also maps management. Info lives under `/identity/bearer/manage/info`, not `/identity/manage/info`, when you signed in on the bearer prefix with cookies.
+- Refresh body field is `refreshToken` (camelCase JSON).

--- a/.cursor/skills/verify-authendpoints/features/reauth.md
+++ b/.cursor/skills/verify-authendpoints/features/reauth.md
@@ -1,0 +1,43 @@
+# ReAuth step-up
+
+A signed-in user must prove their identity again before changing password or other sensitive account fields. The client lists available methods, posts one proof, then sends the issued token on the mutation.
+
+## Sub-features
+
+- `auth-methods` reports `password: true` from `GET /identity/manage/authMethods` after cookie login.
+- `confirm-password` returns `reauthToken` from `POST /identity/confirmIdentity` with `{ "password" }` and CSRF.
+- `confirm-wrong` does not issue a token for the wrong password.
+- `manage-without-reauth` rejects `POST /identity/manage/info` password change without ReAuth.
+- `manage-with-reauth` changes the password when CSRF and `X-AuthEndpoints-Reauth` are present, after which the new password can log in.
+
+## How to get to it (user POV)
+
+- Cookie (or bearer) session first.
+- `GET /identity/manage/authMethods`.
+- `POST /identity/confirmIdentity` JSON with **exactly one** of `password`, `twoFactorCode`, `twoFactorRecoveryCode`, `credentialJson`. Cookie clients also send CSRF.
+- Send `X-AuthEndpoints-Reauth: <reauthToken>` on `POST /identity/manage/info` and `POST /identity/manage/2fa`. Cookie clients still send CSRF.
+- Cookie clients also receive cookie `AuthEndpoints.ReAuth`.
+
+## Driving it with ae-http
+
+Preconditions:
+
+- Host is healthy.
+- Cookie session for `EMAIL` / `PASS` (register + `/identity/login`).
+- Cookie jar still has the application cookie.
+
+- **Methods.** Run `ae-http.sh get /identity/manage/authMethods --out auth-methods`. Status is `200`. `password` is `true`.
+- **Confirm.** Run `ae-http.sh post --csrf /identity/confirmIdentity "{\"password\":\"${PASS}\"}" --out confirm`. Status is `200`. Body has `reauthToken`.
+- **Wrong password.** Run `ae-http.sh post --csrf /identity/confirmIdentity '{"password":"WrongPass1!"}' --out confirm-wrong`. Status is not 200.
+- **Mutation without ReAuth.** Unset `AE_REAUTH`. Run `ae-http.sh post --csrf /identity/manage/info "{\"oldPassword\":\"${PASS}\",\"newPassword\":\"ChangedPass1!\"}" --out info-no-reauth`. Status is `401` or `403`.
+- **Mutation with ReAuth.** `export AE_REAUTH` from the successful confirm. Run `ae-http.sh post --csrf /identity/manage/info "{\"oldPassword\":\"${PASS}\",\"newPassword\":\"ChangedPass1!\"}" --out info-reauth`. Status is `200`.
+- **New password works.** New jar. Run `ae-http.sh post /identity/login "{\"email\":\"${EMAIL}\",\"password\":\"ChangedPass1!\"}" --out login-new`. Status is `200` or `204`. Then `ae-http.sh get /identity/manage/info --out info-new` is `200`.
+- **Proof.** Keep `auth-methods.body`, `confirm.body` (`reauthToken`), `info-no-reauth.status` (401/403), `info-reauth.status` (`200`), and `login-new.status`.
+
+## Gotchas
+
+- Confirm requires **exactly one** proof field. Sending password plus another field is 400.
+- Cookie confirm and manage POSTs need CSRF **and** ReAuth. Bearer-only clients skip CSRF when no application cookie is present.
+- ReAuth tokens are short-lived. Confirm immediately before the mutation.
+- `/test/reauth` only checks the ReAuth cookie. Prefer `manage/info` as the library-facing proof.
+- Confirm is rate-limited (fixed window). Do not loop failed confirms.

--- a/.cursor/skills/verify-authendpoints/features/simple-jwt.md
+++ b/.cursor/skills/verify-authendpoints/features/simple-jwt.md
@@ -1,0 +1,42 @@
+# Simple JWT
+
+A client exchanges email and password for a Bearer access token and an HttpOnly refresh cookie, then calls `/auth/verify` and refreshes with CSRF.
+
+## Sub-features
+
+- `jwt-create` returns `accessToken` from `POST /auth/create` and sets `AuthEndpoints.Jwt.RefreshToken`.
+- `jwt-create-bad` returns 401 `Invalid credentials` for a wrong password.
+- `jwt-verify` accepts `Authorization: Bearer` on `GET /auth/verify` (204 No Content).
+- `jwt-refresh` returns a new access token from `POST /auth/refresh` using the refresh cookie plus CSRF.
+- `jwt-refresh-missing-cookie` fails when the refresh cookie is absent.
+
+## How to get to it (user POV)
+
+- Register the user at `POST /identity/register` (JWT mapping has no register of its own).
+- `POST /auth/create` JSON `{ "email", "password" }`.
+- `GET /auth/verify` with `Authorization: Bearer <accessToken>`.
+- `GET /auth/csrfToken`, then `POST /auth/refresh` with cookies and `RequestVerificationToken`.
+- `POST /auth/logout` with CSRF to clear the refresh cookie.
+
+## Driving it with ae-http
+
+Preconditions:
+
+- Host is healthy.
+- User `EMAIL` exists via `/identity/register`.
+- Fresh cookie jar (JWT refresh cookie must come from `/auth/create`, not from cookie login).
+
+- **Create.** Run `ae-http.sh post /auth/create "{\"email\":\"${EMAIL}\",\"password\":\"${PASS}\"}" --out jwt-create`. Status is `200`. Body has `accessToken` and `tokenType` `Bearer`. Headers set `AuthEndpoints.Jwt.RefreshToken`.
+- **Wrong password.** Run `ae-http.sh post /auth/create "{\"email\":\"${EMAIL}\",\"password\":\"WrongPassword!\"}" --out jwt-create-bad`. Status is `401`. Body contains `Invalid credentials`.
+- **Verify.** `export AE_BEARER` to the access token. Run `ae-http.sh get /auth/verify --out jwt-verify`. Status is `204`.
+- **Refresh.** Keep the jar from create. Run `ae-http.sh post --csrf /auth/refresh --out jwt-refresh`. Status is `200`. Body has a new `accessToken`.
+- **Missing cookie.** New jar, no create. Run `ae-http.sh post --csrf /auth/refresh --out jwt-refresh-missing`. Status is not 200 (typically 400) and the body mentions a missing refresh token cookie.
+- **Proof.** Keep `jwt-create.body` + `jwt-create.headers` (refresh cookie), `jwt-verify.status` (`204`), and `jwt-refresh.body` (new access token).
+
+## Gotchas
+
+- `/auth/create` is rate-limited with the login policy. Space it from other logins.
+- Refresh and logout require CSRF on the **JWT** token endpoint (`/auth/csrfToken`).
+- The access token is only in JSON. The refresh token is **only** in the cookie named `AuthEndpoints.Jwt.RefreshToken`, not in the create JSON.
+- Two-factor users get 401 with `requiresTwoFactor` when no code is sent. This test-host user is not 2FA unless you enabled it.
+- Facade `Jwt.Enabled` is opt-in for hosts. This test host always maps `/auth`.

--- a/.cursor/skills/verify-authendpoints/scripts/ae-http.sh
+++ b/.cursor/skills/verify-authendpoints/scripts/ae-http.sh
@@ -191,7 +191,7 @@ PY
 wait_ready() {
   local i
   for i in $(seq 1 60); do
-    if curl -sS -o /dev/null -w "%{http_code}" "${AE_BASE_URL}/identity/csrfToken" | grep -q '^200$'; then
+    if curl -sS -o /dev/null -w "%{http_code}" --max-time 1 "${AE_BASE_URL}/identity/csrfToken" 2>/dev/null | grep -q '^200$'; then
       return 0
     fi
     sleep 0.5

--- a/.cursor/skills/verify-authendpoints/scripts/ae-http.sh
+++ b/.cursor/skills/verify-authendpoints/scripts/ae-http.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# HTTP harness for the AuthEndpoints in-repo test host.
+# Invoke from the repository root. See ../SKILL.md.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ae-http.sh <command> [args]
+
+Commands:
+  launch              Build and start the test host. Writes pid/url under AE_RUN_DIR.
+  doctor              Read-only health check (process, port, GET /identity/csrfToken).
+  stop                Stop the host started by launch (PID file only). Does not delete evidence.
+  csrf [path]         Print csrfToken JSON field (default /identity/csrfToken).
+  get <path>          GET a path. Writes status/headers/body under AE_EVIDENCE_DIR when --out is set.
+  post <path> [json]  POST JSON. Add --csrf to send RequestVerificationToken. Optional --out NAME.
+
+Environment:
+  AE_RUN_ID         Unique id for this run (default: timestamp-pid)
+  AE_PORT          Listen port (default: 5088)
+  AE_BASE_URL      Base URL (default: http://127.0.0.1:$AE_PORT)
+  AE_RUN_DIR       Scratch dir for pid/log/cookie jar (default: /tmp/authendpoints-verify-$AE_RUN_ID)
+  AE_EVIDENCE_DIR  Proof output dir; never deleted by stop (default: $AE_RUN_DIR/evidence)
+  AE_COOKIE_JAR    curl cookie jar (default: $AE_RUN_DIR/cookies.txt)
+  AE_REPO_ROOT     Repository root (default: git root or cwd)
+
+Examples:
+  AE_RUN_ID=demo ./ae-http.sh launch
+  ./ae-http.sh doctor
+  ./ae-http.sh post /identity/register '{"email":"a@test.local","password":"Passw0rd!"}' --out register
+  ./ae-http.sh post /identity/login '{"email":"a@test.local","password":"Passw0rd!"}' --out login
+  ./ae-http.sh get /identity/manage/info --out info
+  ./ae-http.sh post --csrf /identity/logout --out logout
+  ./ae-http.sh stop
+EOF
+}
+
+json_get() {
+  python3 -c '
+import json, sys
+key_camel, key_pascal = sys.argv[1], sys.argv[2]
+raw = sys.stdin.read()
+if not raw.strip():
+    sys.exit(2)
+doc = json.loads(raw)
+if isinstance(doc, dict):
+    val = doc.get(key_camel)
+    if val is None:
+        val = doc.get(key_pascal)
+    if val is None:
+        sys.exit(3)
+    print(val)
+else:
+    sys.exit(2)
+' "$1" "$2"
+}
+
+retry_sleep() {
+  local attempt="$1"
+  python3 -c "print(min(2 ** ${attempt}, 16))"
+}
+
+http() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local csrf="${4:-}"
+  local out_name="${5:-}"
+  local url="${AE_BASE_URL}${path}"
+  local tmp
+  tmp="$(mktemp)"
+  local args=(
+    -sS
+    -D "${tmp}.headers"
+    -o "${tmp}.body"
+    -w "%{http_code}"
+    -X "$method"
+    -b "$AE_COOKIE_JAR"
+    -c "$AE_COOKIE_JAR"
+    "$url"
+  )
+  if [[ -n "$body" ]]; then
+    args+=(-H "Content-Type: application/json" --data "$body")
+  fi
+  if [[ -n "$csrf" ]]; then
+    args+=(-H "RequestVerificationToken: $csrf")
+  fi
+  if [[ -n "${AE_BEARER:-}" ]]; then
+    args+=(-H "Authorization: Bearer $AE_BEARER")
+  fi
+  if [[ -n "${AE_REAUTH:-}" ]]; then
+    args+=(-H "X-AuthEndpoints-Reauth: $AE_REAUTH")
+  fi
+
+  local attempt status
+  for attempt in 0 1 2 3 4 5; do
+    status="$(curl "${args[@]}")"
+    if [[ "$status" != "429" ]]; then
+      break
+    fi
+    sleep "$(retry_sleep "$attempt")"
+  done
+
+  if [[ -n "$out_name" ]]; then
+    mkdir -p "$AE_EVIDENCE_DIR"
+    printf '%s\n' "$status" > "${AE_EVIDENCE_DIR}/${out_name}.status"
+    cp "${tmp}.headers" "${AE_EVIDENCE_DIR}/${out_name}.headers"
+    cp "${tmp}.body" "${AE_EVIDENCE_DIR}/${out_name}.body"
+    {
+      echo "METHOD $method"
+      echo "URL $url"
+      if [[ -n "$body" ]]; then
+        echo "BODY $body"
+      fi
+    } > "${AE_EVIDENCE_DIR}/${out_name}.request"
+  fi
+
+  AE_LAST_STATUS="$status"
+  AE_LAST_BODY="$(cat "${tmp}.body")"
+  AE_LAST_HEADERS="$(cat "${tmp}.headers")"
+  rm -f "${tmp}.headers" "${tmp}.body" "$tmp"
+  printf '%s' "$AE_LAST_BODY"
+  echo
+  echo "HTTP $status" >&2
+  if [[ "$status" == "429" ]]; then
+    echo "Rate limited after retries. Wait and retry the whole drive." >&2
+    return 1
+  fi
+}
+
+parse_common() {
+  local -a rest=()
+  AE_USE_CSRF=0
+  AE_OUT=""
+  AE_PATH=""
+  AE_JSON=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --csrf) AE_USE_CSRF=1; shift ;;
+      --out) AE_OUT="$2"; shift 2 ;;
+      --help|-h) usage; exit 0 ;;
+      --) shift; rest+=("$@"); break ;;
+      *) rest+=("$1"); shift ;;
+    esac
+  done
+  if [[ ${#rest[@]} -ge 1 ]]; then
+    AE_PATH="${rest[0]}"
+  fi
+  if [[ ${#rest[@]} -ge 2 ]]; then
+    AE_JSON="${rest[1]}"
+  fi
+}
+
+resolve_paths() {
+  if [[ -z "${AE_REPO_ROOT:-}" ]]; then
+    if git rev-parse --show-toplevel >/dev/null 2>&1; then
+      AE_REPO_ROOT="$(git rev-parse --show-toplevel)"
+    else
+      AE_REPO_ROOT="$(pwd)"
+    fi
+  fi
+  AE_RUN_ID="${AE_RUN_ID:-$(date +%Y%m%dT%H%M%S)-$$}"
+  AE_PORT="${AE_PORT:-5088}"
+  AE_BASE_URL="${AE_BASE_URL:-http://127.0.0.1:${AE_PORT}}"
+  AE_RUN_DIR="${AE_RUN_DIR:-/tmp/authendpoints-verify-${AE_RUN_ID}}"
+  AE_EVIDENCE_DIR="${AE_EVIDENCE_DIR:-${AE_RUN_DIR}/evidence}"
+  AE_COOKIE_JAR="${AE_COOKIE_JAR:-${AE_RUN_DIR}/cookies.txt}"
+  AE_PID_FILE="${AE_RUN_DIR}/host.pid"
+  AE_LOG_FILE="${AE_RUN_DIR}/host.log"
+  AE_URL_FILE="${AE_RUN_DIR}/base.url"
+  AE_PROJECT="${AE_REPO_ROOT}/tests/AuthEndpoints.Tests/AuthEndpoints.Tests.csproj"
+  AE_DLL="${AE_REPO_ROOT}/tests/AuthEndpoints.Tests/bin/Debug/net10.0/AuthEndpoints.Tests.dll"
+}
+
+port_in_use() {
+  python3 - "$AE_PORT" <<'PY'
+import socket, sys
+port = int(sys.argv[1])
+s = socket.socket()
+s.settimeout(0.3)
+try:
+    s.connect(("127.0.0.1", port))
+except OSError:
+    sys.exit(1)
+else:
+    s.close()
+    sys.exit(0)
+PY
+}
+
+wait_ready() {
+  local i
+  for i in $(seq 1 60); do
+    if curl -sS -o /dev/null -w "%{http_code}" "${AE_BASE_URL}/identity/csrfToken" | grep -q '^200$'; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "Host did not become ready at ${AE_BASE_URL}/identity/csrfToken" >&2
+  echo "Last log lines:" >&2
+  tail -n 40 "$AE_LOG_FILE" >&2 || true
+  return 1
+}
+
+cmd_launch() {
+  mkdir -p "$AE_RUN_DIR"
+  mkdir -p "$AE_EVIDENCE_DIR"
+  : > "$AE_COOKIE_JAR"
+
+  if ! command -v dotnet >/dev/null 2>&1; then
+    echo "dotnet is not on PATH. Install the .NET 10 SDK and retry." >&2
+    exit 1
+  fi
+  local ver
+  ver="$(dotnet --version)"
+  if [[ "$ver" != 10.* ]]; then
+    echo "Need .NET 10 SDK; got ${ver}" >&2
+    exit 1
+  fi
+  if [[ ! -f "$AE_PROJECT" ]]; then
+    echo "Missing test project at $AE_PROJECT" >&2
+    exit 1
+  fi
+  if port_in_use; then
+    echo "Port ${AE_PORT} is already answering. Pick another AE_PORT; do not drive a shared instance." >&2
+    exit 1
+  fi
+
+  echo "Building $AE_PROJECT" >&2
+  dotnet build "$AE_PROJECT" -c Debug -v q
+  if [[ ! -f "$AE_DLL" ]]; then
+    echo "Build succeeded but $AE_DLL is missing." >&2
+    exit 1
+  fi
+
+  echo "Starting host on ${AE_BASE_URL}" >&2
+  (
+    cd "$(dirname "$AE_DLL")"
+    exec env \
+      ASPNETCORE_ENVIRONMENT=Development \
+      ASPNETCORE_URLS="$AE_BASE_URL" \
+      ASPNETCORE_HTTP_PORTS="" \
+      ASPNETCORE_HTTPS_PORTS="" \
+      TestDbName="AuthEndpointsVerify_${AE_RUN_ID}" \
+      DOTNET_ENVIRONMENT=Development \
+      dotnet "$AE_DLL"
+  ) >"$AE_LOG_FILE" 2>&1 &
+  echo $! > "$AE_PID_FILE"
+  echo "$AE_BASE_URL" > "$AE_URL_FILE"
+  if ! wait_ready; then
+    cmd_stop || true
+    exit 1
+  fi
+  echo "Ready at ${AE_BASE_URL} (pid $(cat "$AE_PID_FILE"))" >&2
+  echo "$AE_BASE_URL"
+}
+
+cmd_doctor() {
+  if [[ ! -f "$AE_PID_FILE" ]]; then
+    echo "No pid file at $AE_PID_FILE — this run did not start a host." >&2
+    exit 1
+  fi
+  local pid
+  pid="$(cat "$AE_PID_FILE")"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "Pid $pid is not running. Host is down." >&2
+    exit 1
+  fi
+  if ! port_in_use; then
+    echo "Pid $pid is running but ${AE_BASE_URL} is not accepting connections." >&2
+    exit 1
+  fi
+  local body status
+  status="$(curl -sS -o "${AE_RUN_DIR}/doctor.body" -w "%{http_code}" "${AE_BASE_URL}/identity/csrfToken")"
+  if [[ "$status" != "200" ]]; then
+    echo "GET /identity/csrfToken returned HTTP $status (want 200)." >&2
+    cat "${AE_RUN_DIR}/doctor.body" >&2 || true
+    exit 1
+  fi
+  json_get csrfToken CsrfToken < "${AE_RUN_DIR}/doctor.body" >/dev/null
+  echo "ok pid=$pid url=${AE_BASE_URL} csrfToken=present"
+}
+
+cmd_stop() {
+  if [[ ! -f "$AE_PID_FILE" ]]; then
+    echo "No pid file; nothing to stop." >&2
+    return 0
+  fi
+  local pid
+  pid="$(cat "$AE_PID_FILE")"
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid"
+    local i
+    for i in $(seq 1 20); do
+      if ! kill -0 "$pid" 2>/dev/null; then
+        break
+      fi
+      sleep 0.25
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" || true
+    fi
+  fi
+  rm -f "$AE_PID_FILE"
+  echo "Stopped pid $pid. Evidence kept at ${AE_EVIDENCE_DIR}" >&2
+}
+
+cmd_csrf() {
+  local path="${1:-/identity/csrfToken}"
+  http GET "$path" "" "" "" >/dev/null
+  printf '%s' "$AE_LAST_BODY" | json_get csrfToken CsrfToken
+  echo
+}
+
+cmd_get() {
+  parse_common "$@"
+  if [[ -z "$AE_PATH" ]]; then
+    echo "get requires a path" >&2
+    exit 1
+  fi
+  http GET "$AE_PATH" "" "" "$AE_OUT"
+}
+
+cmd_post() {
+  parse_common "$@"
+  if [[ -z "$AE_PATH" ]]; then
+    echo "post requires a path" >&2
+    exit 1
+  fi
+  local csrf=""
+  if [[ "$AE_USE_CSRF" == "1" ]]; then
+    local csrf_path="/identity/csrfToken"
+    case "$AE_PATH" in
+      /auth/*) csrf_path="/auth/csrfToken" ;;
+    esac
+    csrf="$(AE_OUT="" http GET "$csrf_path" "" "" "" >/dev/null; printf '%s' "$AE_LAST_BODY" | json_get csrfToken CsrfToken)"
+  fi
+  http POST "$AE_PATH" "$AE_JSON" "$csrf" "$AE_OUT"
+}
+
+resolve_paths
+cmd="${1:-}"
+if [[ -n "$cmd" ]]; then
+  shift
+fi
+case "$cmd" in
+  launch) cmd_launch "$@" ;;
+  doctor) cmd_doctor "$@" ;;
+  stop) cmd_stop "$@" ;;
+  csrf) cmd_csrf "$@" ;;
+  get) cmd_get "$@" ;;
+  post) cmd_post "$@" ;;
+  -h|--help|help|"") usage ;;
+  *) echo "Unknown command: $cmd" >&2; usage; exit 1 ;;
+esac


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a project-local verification skill that later agents can follow cold: launch the in-repo test host, doctor it, drive cookie/bearer/JWT/CSRF/ReAuth the way a client would, and keep response files as proof.

## Why

This repo is a library. `dotnet test` is necessary but does not show a live client path (cookies, CSRF header, refresh cookie). Cloud agents need a scripted way to start `tests/AuthEndpoints.Tests` and call the mapped routes.

## What’s included

- `.cursor/skills/verify-authendpoints/SKILL.md` — launch, doctor, drive, evidence, cleanup
- `features/` — cookie session, CSRF, Identity bearer, Simple JWT, ReAuth
- `scripts/ae-http.sh` — build/start the test host, curl with cookie jar, CSRF, 429 retries

## How to use

```bash
export AE_RUN_ID=demo AE_PORT=5088
.cursor/skills/verify-authendpoints/scripts/ae-http.sh launch
.cursor/skills/verify-authendpoints/scripts/ae-http.sh doctor
# drive a mapped feature, then:
.cursor/skills/verify-authendpoints/scripts/ae-http.sh stop
```

The test host still differs from production facade defaults (`RequireConfirmedAccount` is false; relaxed passwords; in-memory DB).

## Prove-out

Ran the generated skill end to end on this branch: launch → doctor → **cookie-session** → evidence → stop. After stop, the evidence directory was still present and port 5088 was closed.

Cookie-session results:

| Step | HTTP |
| --- | --- |
| `POST /identity/register` | 200 |
| invalid email register | 400 |
| `POST /identity/login` | 200 + `.AspNetCore.Identity.Application` |
| `GET /identity/manage/info` | 200, email matches |
| `POST /identity/logout` with CSRF | 200 |
| `GET /identity/manage/info` after logout | 401 |

Upkeep: `/maintain-verification-skill` when mappings or CSRF/login flags change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c04213d5-1b55-4521-991a-f57a60b08a11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c04213d5-1b55-4521-991a-f57a60b08a11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

