### PR TITLE
Optional factory for passwordless passkey user ids

### DIFF
--- a/Documentation/content/3.modules/5.passkeys.md
+++ b/Documentation/content/3.modules/5.passkeys.md
@@ -15,6 +15,14 @@ builder.Services.AddPasskeyEndpoints<AppUser>();
 
 This registers passkey rate limits/ReAuth and the default `IdentityPasskeySignInCompleter<AppUser>`. Prefer the generic overload for compose hosts so register/login can resolve `IPasskeySignInCompleter<TUser>`.
 
+To choose the user id minted during passwordless register:
+
+```cs
+builder.Services.AddPasskeyUserIdFactory(() => Ulid.NewUlid().ToString());
+```
+
+Or register an `IPasskeyUserIdFactory` implementation. When no custom factory is registered, the id is `Guid.NewGuid()` (UUID v4).
+
 Facade: passkeys are **enabled by default**; set `Passkeys.ServerDomain` (required in Production).
 
 ## Map
@@ -91,7 +99,7 @@ Facade JWT opt-in does **not** auto-select the JWT completer — register it exp
 
 ## Constraints
 
-- Passwordless register needs `IdentityUser` with `string` or `Guid` key.
+- Passwordless register needs `IdentityUser` with `string` or `Guid` key. The default user id is `Guid.NewGuid()` (UUID v4). Apps can override the minted id by registering `IPasskeyUserIdFactory`.
 - CSRF is required for WebAuthn ceremonies.
 - Sensitive credential mutations require ReAuth.
 

--- a/Documentation/content/versions/v3.0.3.md
+++ b/Documentation/content/versions/v3.0.3.md
@@ -2,7 +2,6 @@
 title: v3.0.3
 description: Identity bearer facade for native and mobile clients.
 date: 2026-09-02
-badge: Latest
 tag: v3.0.3
 ---
 

--- a/Documentation/content/versions/v3.0.4.md
+++ b/Documentation/content/versions/v3.0.4.md
@@ -1,0 +1,25 @@
+---
+title: v3.0.4
+description: Optional factory for the user id minted during passwordless passkey registration.
+date: 2026-09-04
+badge: Latest
+tag: v3.0.4
+---
+
+### AuthEndpoints
+
+Passwordless passkey registration still mints `Guid.NewGuid()` (UUID v4) by default. Apps can register `IPasskeyUserIdFactory` (or `AddPasskeyUserIdFactory`) to choose a different user id on `RegisterOptions` / `Register`. Cookie and Identity bearer facades are unchanged.
+
+- Default remains `Guid.NewGuid().ToString()` when no factory is registered
+- Passwordless register still supports only `string` and `Guid` Identity keys
+
+### Packages
+
+- **AuthEndpoints** `3.0.4`
+- **AuthEndpoints.External.OAuth** unchanged at `3.0.0-preview.3`
+
+### Links
+
+- [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/v3.0.4)
+- [Compare](https://github.com/madeyoga/AuthEndpoints/compare/v3.0.3...v3.0.4)
+- [Installation](/getting-started/installation)

--- a/skills/authendpoints/SKILL.md
+++ b/skills/authendpoints/SKILL.md
@@ -10,7 +10,7 @@ Ready-made Identity auth API endpoints for first-party web and mobile clients. T
 
 Canonical docs: https://madeyoga.github.io/AuthEndpoints — follow those pages; do not invent APIs.
 
-Requires **.NET 10**, ASP.NET Core Identity, and EF Core. The host `DbContext` is typically `IdentityDbContext<TUser>` (or with roles). `TUser` may use any Identity key type (`string`, `Guid`, `long`, …). Passwordless passkey **account register** needs a `string` or `Guid` key.
+Requires **.NET 10**, ASP.NET Core Identity, and EF Core. The host `DbContext` is typically `IdentityDbContext<TUser>` (or with roles). `TUser` may use any Identity key type (`string`, `Guid`, `long`, …). Passwordless passkey **account register** needs a `string` or `Guid` key. The minted user id defaults to `Guid.NewGuid()` (UUID v4); register `IPasskeyUserIdFactory` to choose a different id.
 
 ## Install
 
@@ -176,7 +176,7 @@ Full table: https://madeyoga.github.io/AuthEndpoints/getting-started/configurati
 
 Enabled by default. In Production set `Passkeys.ServerDomain`, or disable with `o.Passkeys.Enabled = false`.
 
-Mapped under `{PasskeyPath}/passkeys` (default `/account/passkeys`). CSRF is required for WebAuthn ceremonies. Add/rename/delete/`creationOptions` also require ReAuth.
+Mapped under `{PasskeyPath}/passkeys` (default `/account/passkeys`). CSRF is required for WebAuthn ceremonies. Add/rename/delete/`creationOptions` also require ReAuth. Passwordless register mints `Guid.NewGuid()` (UUID v4) unless the host registers `IPasskeyUserIdFactory`.
 
 Facade JWT opt-in does **not** auto-select `JwtPasskeySignInCompleter`. Register it explicitly when passkey register/login should issue Simple JWT (access token + refresh cookie); that completer ignores cookie query flags.
 

--- a/src/AuthEndpoints/AuthEndpoints.csproj
+++ b/src/AuthEndpoints/AuthEndpoints.csproj
@@ -6,19 +6,23 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Description>Auth library that provides a set of minimal api endpoints to handle authentication actions</Description>
-    <Version>3.0.3</Version>
+    <Version>3.0.4</Version>
     <Authors>madeyoga</Authors>
     <Company>madeyoga</Company>
     <PackageProjectUrl>https://github.com/madeyoga/AuthEndpoints</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/madeyoga/AuthEndpoints</RepositoryUrl>
     <PackageTags>auth;endpoints;aspnetcore;jwt;passkey;webauthn;2fa;identity</PackageTags>
-    <PackageReleaseNotes>Facade SignIn option for Identity bearer login on MapAuthEndpoints.</PackageReleaseNotes>
+    <PackageReleaseNotes>Optional IPasskeyUserIdFactory for the user id minted during passwordless passkey registration.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="AuthEndpoints.Tests" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\README.md">

--- a/src/AuthEndpoints/Passkey/DefaultPasskeyUserIdFactory.cs
+++ b/src/AuthEndpoints/Passkey/DefaultPasskeyUserIdFactory.cs
@@ -1,0 +1,9 @@
+namespace AuthEndpoints.Passkey;
+
+/// <summary>
+/// Default <see cref="IPasskeyUserIdFactory"/> — <c>Guid.NewGuid().ToString()</c> (UUID v4).
+/// </summary>
+public sealed class DefaultPasskeyUserIdFactory : IPasskeyUserIdFactory
+{
+    public string CreateUserId() => Guid.NewGuid().ToString();
+}

--- a/src/AuthEndpoints/Passkey/IPasskeyUserIdFactory.cs
+++ b/src/AuthEndpoints/Passkey/IPasskeyUserIdFactory.cs
@@ -1,0 +1,14 @@
+namespace AuthEndpoints.Passkey;
+
+/// <summary>
+/// Mints the user id embedded in WebAuthn creation options during passwordless
+/// passkey registration. The default is <c>Guid.NewGuid().ToString()</c> (UUID v4).
+/// </summary>
+public interface IPasskeyUserIdFactory
+{
+    /// <summary>
+    /// Returns the user id string used as the WebAuthn user handle for a new account.
+    /// Register later copies this value from the attestation <c>userEntity.Id</c>.
+    /// </summary>
+    string CreateUserId();
+}

--- a/src/AuthEndpoints/Passkey/PasskeyEndpoints.cs
+++ b/src/AuthEndpoints/Passkey/PasskeyEndpoints.cs
@@ -184,7 +184,8 @@ public static class PasskeyEndpoints<TUser>
     public static async Task<Results<ContentHttpResult, ValidationProblem, ProblemHttpResult>> RegisterOptions(
         [FromBody] PasskeyRegisterOptionsRequest request,
         UserManager<TUser> userManager,
-        SignInManager<TUser> signInManager)
+        SignInManager<TUser> signInManager,
+        IPasskeyUserIdFactory userIdFactory)
     {
         if (!userManager.SupportsUserEmail)
         {
@@ -201,7 +202,7 @@ public static class PasskeyEndpoints<TUser>
         }
 
         // Always return creation options (even if the email exists) to avoid account enumeration.
-        var userId = UserIdHelper.CreateUserIdString(typeof(TUser));
+        var userId = UserIdHelper.CreateUserIdString(typeof(TUser), userIdFactory);
         var optionsJson = await signInManager.MakePasskeyCreationOptionsAsync(new()
         {
             Id = userId,

--- a/src/AuthEndpoints/Passkey/ServiceCollectionExtensions.cs
+++ b/src/AuthEndpoints/Passkey/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddReAuthScheme();
         services.AddIdentityEndpointRateLimiting();
+        services.TryAddSingleton<IPasskeyUserIdFactory, DefaultPasskeyUserIdFactory>();
 
         if (services.Any(d => d.ServiceType == typeof(PasskeyRateLimitMarker)))
         {
@@ -78,5 +79,32 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped<IPasskeySignInCompleter<TUser>, TCompleter>();
         return services;
+    }
+
+    /// <summary>
+    /// Replaces the default <see cref="IPasskeyUserIdFactory"/> used when minting
+    /// a user id during passwordless passkey registration.
+    /// </summary>
+    public static IServiceCollection AddPasskeyUserIdFactory<TFactory>(this IServiceCollection services)
+        where TFactory : class, IPasskeyUserIdFactory
+    {
+        services.AddSingleton<IPasskeyUserIdFactory, TFactory>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a callback as the <see cref="IPasskeyUserIdFactory"/> used when minting
+    /// a user id during passwordless passkey registration.
+    /// </summary>
+    public static IServiceCollection AddPasskeyUserIdFactory(this IServiceCollection services, Func<string> createUserId)
+    {
+        ArgumentNullException.ThrowIfNull(createUserId);
+        services.AddSingleton<IPasskeyUserIdFactory>(new DelegatePasskeyUserIdFactory(createUserId));
+        return services;
+    }
+
+    private sealed class DelegatePasskeyUserIdFactory(Func<string> createUserId) : IPasskeyUserIdFactory
+    {
+        public string CreateUserId() => createUserId();
     }
 }

--- a/src/AuthEndpoints/Passkey/UserIdHelper.cs
+++ b/src/AuthEndpoints/Passkey/UserIdHelper.cs
@@ -6,14 +6,14 @@ namespace AuthEndpoints.Passkey;
 
 internal static class UserIdHelper
 {
-    public static string CreateUserIdString(Type userType)
+    public static string CreateUserIdString(Type userType, IPasskeyUserIdFactory? factory = null)
     {
         var keyType = TypeHelper.FindKeyType(userType)
             ?? throw new InvalidOperationException("Generic type TUser is not IdentityUser.");
 
         if (keyType == typeof(string) || keyType == typeof(Guid))
         {
-            return Guid.NewGuid().ToString();
+            return factory?.CreateUserId() ?? Guid.NewGuid().ToString();
         }
 
         throw new NotSupportedException(

--- a/tests/AuthEndpoints.Tests/PasskeyEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/PasskeyEndpointsTests.cs
@@ -1,5 +1,8 @@
 ﻿using System.Net;
+using System.Text;
 using System.Text.Json;
+using AuthEndpoints.Passkey;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace AuthEndpoints.Tests;
 
@@ -10,6 +13,55 @@ public class PasskeyEndpointsTests : IClassFixture<TestWebApplicationFactory>
     public PasskeyEndpointsTests(TestWebApplicationFactory factory)
     {
         _factory = factory;
+    }
+
+    [Fact]
+    public async Task RegisterOptions_Default_MintsGuidShapedUserId()
+    {
+        var email = $"passkey-guid-{Guid.NewGuid():N}@test.local";
+        using var client = TestHelpers.CreateClientWithCookies(_factory);
+
+        var csrf = await TestHelpers.GetCsrfTokenAsync(client);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/account/passkeys/register/options")
+        {
+            Content = JsonContent.Create(new { email })
+        };
+        request.Headers.Add("RequestVerificationToken", csrf);
+
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var userId = ReadCreationOptionsUserId(await response.Content.ReadAsStringAsync());
+        Assert.True(Guid.TryParse(userId, out _), $"Expected a Guid-shaped id, got '{userId}'.");
+    }
+
+    [Fact]
+    public async Task RegisterOptions_RegisteredFactory_UsesFactoryId()
+    {
+        const string expectedId = "factory-minted-user-id";
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddPasskeyUserIdFactory(() => expectedId);
+            });
+        });
+
+        var email = $"passkey-factory-{Guid.NewGuid():N}@test.local";
+        using var client = TestHelpers.CreateClientWithCookies(factory);
+
+        var csrf = await TestHelpers.GetCsrfTokenAsync(client);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/account/passkeys/register/options")
+        {
+            Content = JsonContent.Create(new { email })
+        };
+        request.Headers.Add("RequestVerificationToken", csrf);
+
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var userId = ReadCreationOptionsUserId(await response.Content.ReadAsStringAsync());
+        Assert.Equal(expectedId, userId);
     }
 
     [Fact]
@@ -59,5 +111,32 @@ public class PasskeyEndpointsTests : IClassFixture<TestWebApplicationFactory>
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("Unable to complete registration", body, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("already exists", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static string ReadCreationOptionsUserId(string optionsJson)
+    {
+        using var doc = JsonDocument.Parse(optionsJson);
+        Assert.True(
+            doc.RootElement.TryGetProperty("user", out var user)
+            || doc.RootElement.TryGetProperty("User", out user),
+            "Expected user in creation options JSON.");
+
+        var id = TestHelpers.TryGetString(user, "id", "Id");
+        Assert.False(string.IsNullOrWhiteSpace(id), "Expected user.id in creation options JSON.");
+
+        if (Guid.TryParse(id, out _))
+        {
+            return id;
+        }
+
+        try
+        {
+            var bytes = WebEncoders.Base64UrlDecode(id);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        catch (FormatException)
+        {
+            return id;
+        }
     }
 }

--- a/tests/AuthEndpoints.Tests/PasskeyEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/PasskeyEndpointsTests.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Text.Json;
 using AuthEndpoints.Passkey;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 
 namespace AuthEndpoints.Tests;
@@ -48,7 +49,11 @@ public class PasskeyEndpointsTests : IClassFixture<TestWebApplicationFactory>
         });
 
         var email = $"passkey-factory-{Guid.NewGuid():N}@test.local";
-        using var client = TestHelpers.CreateClientWithCookies(factory);
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = true
+        });
 
         var csrf = await TestHelpers.GetCsrfTokenAsync(client);
         using var request = new HttpRequestMessage(HttpMethod.Post, "/account/passkeys/register/options")

--- a/tests/AuthEndpoints.Tests/PasskeySignInCompleterTests.cs
+++ b/tests/AuthEndpoints.Tests/PasskeySignInCompleterTests.cs
@@ -50,6 +50,37 @@ public class PasskeySignInCompleterTests : IClassFixture<TestWebApplicationFacto
     }
 
     [Fact]
+    public void AddPasskeyEndpoints_RegistersDefaultPasskeyUserIdFactory()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IPasskeyUserIdFactory>();
+        Assert.IsType<DefaultPasskeyUserIdFactory>(factory);
+        Assert.True(Guid.TryParse(factory.CreateUserId(), out _), "Default factory should mint a Guid-shaped id.");
+    }
+
+    [Fact]
+    public void AddPasskeyUserIdFactory_ReplacesDefaultFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<TestDbContext>(o =>
+            o.UseInMemoryDatabase("PasskeyUserIdFactoryReplace_" + Guid.NewGuid().ToString("N")));
+        services
+            .AddIdentityApiEndpoints<TestAppUser>(o =>
+            {
+                o.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
+            })
+            .AddEntityFrameworkStores<TestDbContext>()
+            .AddDefaultTokenProviders();
+        services.AddPasskeyEndpoints<TestAppUser>();
+        services.AddPasskeyUserIdFactory(() => "replaced-user-id");
+
+        using var sp = services.BuildServiceProvider();
+        var factory = sp.GetRequiredService<IPasskeyUserIdFactory>();
+        Assert.Equal("replaced-user-id", factory.CreateUserId());
+    }
+
+    [Fact]
     public void AddPasskeySignInCompleter_ReplacesDefaultWithJwtCompleter()
     {
         var services = new ServiceCollection();

--- a/tests/AuthEndpoints.Tests/UserIdHelperTests.cs
+++ b/tests/AuthEndpoints.Tests/UserIdHelperTests.cs
@@ -1,0 +1,90 @@
+using AuthEndpoints.Passkey;
+using Microsoft.AspNetCore.Identity;
+
+namespace AuthEndpoints.Tests;
+
+public class UserIdHelperTests
+{
+    [Fact]
+    public void CreateUserIdString_StringKey_ReturnsGuidShapedId()
+    {
+        var userId = UserIdHelper.CreateUserIdString(typeof(IdentityUser));
+
+        Assert.True(Guid.TryParse(userId, out _), $"Expected a Guid-shaped id, got '{userId}'.");
+    }
+
+    [Fact]
+    public void CreateUserIdString_GuidKey_ReturnsGuidShapedId()
+    {
+        var userId = UserIdHelper.CreateUserIdString(typeof(IdentityUser<Guid>));
+
+        Assert.True(Guid.TryParse(userId, out _), $"Expected a Guid-shaped id, got '{userId}'.");
+    }
+
+    [Fact]
+    public void CreateUserIdString_LongKey_ThrowsNotSupported()
+    {
+        var ex = Assert.Throws<NotSupportedException>(
+            () => UserIdHelper.CreateUserIdString(typeof(IdentityUser<long>)));
+
+        Assert.Contains("string or Guid", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateUserIdString_StringKey_UsesRegisteredFactory()
+    {
+        var factory = new FixedPasskeyUserIdFactory("custom-string-key-id");
+
+        var userId = UserIdHelper.CreateUserIdString(typeof(IdentityUser), factory);
+
+        Assert.Equal("custom-string-key-id", userId);
+    }
+
+    [Fact]
+    public void CreateUserIdString_GuidKey_UsesRegisteredFactory()
+    {
+        var expected = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var factory = new FixedPasskeyUserIdFactory(expected.ToString());
+
+        var userId = UserIdHelper.CreateUserIdString(typeof(IdentityUser<Guid>), factory);
+
+        Assert.Equal(expected.ToString(), userId);
+    }
+
+    [Fact]
+    public void CreateUserIdString_LongKey_ThrowsEvenWhenFactoryIsRegistered()
+    {
+        var factory = new FixedPasskeyUserIdFactory("1");
+
+        var ex = Assert.Throws<NotSupportedException>(
+            () => UserIdHelper.CreateUserIdString(typeof(IdentityUser<long>), factory));
+
+        Assert.Contains("string or Guid", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SetUserId_StringKey_AssignsId()
+    {
+        var user = new IdentityUser();
+
+        UserIdHelper.SetUserId(user, "string-user-id");
+
+        Assert.Equal("string-user-id", user.Id);
+    }
+
+    [Fact]
+    public void SetUserId_GuidKey_AssignsId()
+    {
+        var user = new IdentityUser<Guid>();
+        var id = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+        UserIdHelper.SetUserId(user, id.ToString());
+
+        Assert.Equal(id, user.Id);
+    }
+
+    private sealed class FixedPasskeyUserIdFactory(string userId) : IPasskeyUserIdFactory
+    {
+        public string CreateUserId() => userId;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Passwordless passkey registration still mints `Guid.NewGuid()` (UUID v4) by default. Apps can register `IPasskeyUserIdFactory` (or `AddPasskeyUserIdFactory`) to choose the user id used on `RegisterOptions` / `Register`.

## Behavior

- No custom factory: `RegisterOptions` still pre-allocates `Guid.NewGuid().ToString()` before `MakePasskeyCreationOptionsAsync`
- Custom factory: that id is embedded in creation options; `Register` still applies `userEntity.Id` via `SetUserId`
- Passwordless register still supports only `string` and `Guid` Identity keys (`NotSupportedException` for other key types, including `long`)
- `LoginCookie`, `MapCookieAuthEndpoints`, `MapBearerAuthEndpoints`, and `AuthEndpointsSignIn.Cookie` / `IdentityBearer` are unchanged

## Package

- AuthEndpoints **3.0.4**
- AuthEndpoints.External.OAuth unchanged at `3.0.0-preview.3`

## Tests

- Default mint is Guid-shaped
- Registered factory is used for `RegisterOptions` id
- `string` and `Guid` user types still work
- `long` key still throws on passwordless register options

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-101bd143-6af1-4540-a317-7ae2548a3dee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-101bd143-6af1-4540-a317-7ae2548a3dee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

