### PR TITLE
fix(passkeys): refuse register when attestation user id exists

### DIFF
--- a/.cursor/skills/verify-authendpoints/features/passkeys.md
+++ b/.cursor/skills/verify-authendpoints/features/passkeys.md
@@ -8,6 +8,7 @@ Passwordless passkey register and login on `/account/passkeys`. Register creates
 - `register-create` creates an unconfirmed user, stores the passkey, and sends a confirmation email.
 - `register-unconfirmed-no-session` returns 200 with `credentialId` and no application cookie when `RequireConfirmedAccount` is true.
 - `register-duplicate` returns 400 `Unable to complete registration` for an existing email and does not send mail.
+- `register-existing-id` returns 400 `Unable to complete registration` when attestation `userEntity.Id` already exists and does not attach a passkey. Add credentials on an existing account with authenticated `creationOptions` + `POST /passkeys/`.
 - `confirm-then-login` confirms the emailed link, then passkey login with `?useCookies=true` establishes a session.
 
 ## How to get to it (user POV)

--- a/Documentation/content/3.modules/5.passkeys.md
+++ b/Documentation/content/3.modules/5.passkeys.md
@@ -53,7 +53,7 @@ Routes are mapped under `{prefix}/passkeys` (facade default `/account/passkeys`)
 2. Browser `navigator.credentials.create(...)`
 3. `POST /account/passkeys/register` with `{ "email": "...", "credentialJson": "..." }`
 
-A successful **user create** sends the same confirmation email as password `POST /register`. The account is not marked confirmed. Completers still skip a session when `CanSignInAsync` fails (for example `RequireConfirmedAccount`). Duplicate-email and failed-attestation paths do not send that mail.
+A successful **user create** sends the same confirmation email as password `POST /register`. The account is not marked confirmed. Completers still skip a session when `CanSignInAsync` fails (for example `RequireConfirmedAccount`). Duplicate-email and failed-attestation paths do not send that mail. Passwordless register never attaches a passkey to an existing user id; add a credential to an existing account with authenticated `POST /passkeys/creationOptions` then `POST /passkeys/`.
 
 ## Sign-in completer
 

--- a/src/AuthEndpoints/Passkey/PasskeyEndpoints.cs
+++ b/src/AuthEndpoints/Passkey/PasskeyEndpoints.cs
@@ -268,24 +268,24 @@ public static class PasskeyEndpoints<TUser>
         }
 
         var userEntity = attestationResult.UserEntity;
-        var user = await userManager.FindByIdAsync(userEntity.Id);
-        var createdUser = false;
-        if (user is null)
+        if (await userManager.FindByIdAsync(userEntity.Id) is not null)
         {
-            user = new TUser();
-            UserIdHelper.SetUserId(user, userEntity.Id);
-            await userStore.SetUserNameAsync(user, email, CancellationToken.None);
-            await emailStore.SetEmailAsync(user, email, CancellationToken.None);
+            return TypedResults.Problem(
+                detail: "Unable to complete registration.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
 
-            var createUserResult = await userManager.CreateAsync(user);
-            if (!createUserResult.Succeeded)
-            {
-                return TypedResults.Problem(
-                    detail: "Unable to complete registration.",
-                    statusCode: StatusCodes.Status400BadRequest);
-            }
+        var user = new TUser();
+        UserIdHelper.SetUserId(user, userEntity.Id);
+        await userStore.SetUserNameAsync(user, email, CancellationToken.None);
+        await emailStore.SetEmailAsync(user, email, CancellationToken.None);
 
-            createdUser = true;
+        var createUserResult = await userManager.CreateAsync(user);
+        if (!createUserResult.Succeeded)
+        {
+            return TypedResults.Problem(
+                detail: "Unable to complete registration.",
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         var addPasskeyResult = await userManager.AddOrUpdatePasskeyAsync(user, attestationResult.Passkey);
@@ -296,15 +296,12 @@ public static class PasskeyEndpoints<TUser>
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        if (createdUser)
-        {
-            await IdentityApiEndpoints<TUser>.SendConfirmationEmailAsync(
-                user,
-                userManager,
-                httpContext,
-                email,
-                confirmEmailEndpointName);
-        }
+        await IdentityApiEndpoints<TUser>.SendConfirmationEmailAsync(
+            user,
+            userManager,
+            httpContext,
+            email,
+            confirmEmailEndpointName);
 
         return await completer.CompleteAsync(
             httpContext,

--- a/tests/AuthEndpoints.Tests/PasskeyEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/PasskeyEndpointsTests.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Text.Json;
 using AuthEndpoints.Passkey;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -91,6 +92,69 @@ public class PasskeyEndpointsTests : IClassFixture<TestWebApplicationFactory>
         Assert.DoesNotContain("already exists", body, StringComparison.OrdinalIgnoreCase);
         using var doc = JsonDocument.Parse(body);
         Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task Register_ExistingUserId_ReturnsGenericBadRequestWithoutAttachingPasskey()
+    {
+        var existingUserId = Guid.NewGuid().ToString();
+        var existingEmail = $"passkey-existing-id-{Guid.NewGuid():N}@test.local";
+        var freeEmail = $"passkey-free-{Guid.NewGuid():N}@test.local";
+
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddPasskeyUserIdFactory(() => existingUserId);
+            });
+        });
+
+        int passkeyCountBefore;
+        using (var seedScope = factory.Services.CreateScope())
+        {
+            var userManager = seedScope.ServiceProvider.GetRequiredService<UserManager<TestAppUser>>();
+            var seeded = new TestAppUser
+            {
+                Id = existingUserId,
+                UserName = existingEmail,
+                Email = existingEmail,
+                EmailConfirmed = true
+            };
+            var create = await userManager.CreateAsync(seeded, TestHelpers.DefaultPassword);
+            Assert.True(create.Succeeded, string.Join("; ", create.Errors.Select(e => e.Description)));
+            passkeyCountBefore = (await userManager.GetPasskeysAsync(seeded)).Count;
+        }
+
+        using var client = TestHelpers.CreateClientWithCookies(factory);
+        var origin = client.BaseAddress!.GetLeftPart(UriPartial.Authority);
+        var authenticator = factory.Services.GetRequiredService<SoftwareWebAuthnAuthenticator>();
+
+        var optionsResponse = await TestHelpers.PostWithCsrfAsync(
+            client,
+            "/account/passkeys/register/options",
+            new { email = freeEmail });
+        Assert.Equal(HttpStatusCode.OK, optionsResponse.StatusCode);
+        var optionsJson = await optionsResponse.Content.ReadAsStringAsync();
+        Assert.Equal(existingUserId, ReadCreationOptionsUserId(optionsJson));
+
+        var credentialJson = authenticator.CreateAttestation(optionsJson, origin);
+        var register = await TestHelpers.PostWithCsrfAsync(
+            client,
+            "/account/passkeys/register",
+            new { email = freeEmail, credentialJson });
+        Assert.Equal(HttpStatusCode.BadRequest, register.StatusCode);
+
+        var body = await register.Content.ReadAsStringAsync();
+        Assert.Contains("Unable to complete registration", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("already exists", body, StringComparison.OrdinalIgnoreCase);
+
+        using var afterScope = factory.Services.CreateScope();
+        var afterUserManager = afterScope.ServiceProvider.GetRequiredService<UserManager<TestAppUser>>();
+        var existing = await afterUserManager.FindByIdAsync(existingUserId);
+        Assert.NotNull(existing);
+        Assert.Equal(existingEmail, await afterUserManager.GetEmailAsync(existing));
+        Assert.Equal(passkeyCountBefore, (await afterUserManager.GetPasskeysAsync(existing)).Count);
+        Assert.Null(await afterUserManager.FindByEmailAsync(freeEmail));
     }
 
     [Fact]


### PR DESCRIPTION
Passwordless register only creates a new account; if the attested user id already exists, return generic 400 and do not store a passkey.

Existing accounts add passkeys via signed-in creationOptions + POST /passkeys/.

Tests: existing id → 400, passkey count unchanged.