### PR TITLE
Bump AuthEndpoints to 3.0.5

### DIFF
--- a/Documentation/content/versions/v3.0.4.md
+++ b/Documentation/content/versions/v3.0.4.md
@@ -2,7 +2,6 @@
 title: v3.0.4
 description: Optional factory for the user id minted during passwordless passkey registration.
 date: 2026-09-04
-badge: Latest
 tag: v3.0.4
 ---
 

--- a/Documentation/content/versions/v3.0.5.md
+++ b/Documentation/content/versions/v3.0.5.md
@@ -1,0 +1,26 @@
+---
+title: v3.0.5
+description: Passwordless passkey register sends confirmation email; register creates only new accounts.
+date: 2026-09-06
+badge: Latest
+tag: v3.0.5
+---
+
+### AuthEndpoints
+
+Passwordless passkey register sends the same confirmation email as password register after a successful account create. Register only creates a new account: the attested user id must be new. Signed-in `POST /passkeys/` still adds passkeys to existing accounts.
+
+- Confirmation email is sent after passwordless register creates a user
+- Passwordless register requires a new attested user id
+- Existing accounts still add passkeys via signed-in `POST /passkeys/`
+
+### Packages
+
+- **AuthEndpoints** `3.0.5`
+- **AuthEndpoints.External.OAuth** unchanged at `3.0.0-preview.3`
+
+### Links
+
+- [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/v3.0.5)
+- [Compare](https://github.com/madeyoga/AuthEndpoints/compare/v3.0.4...v3.0.5)
+- [Installation](/getting-started/installation)

--- a/src/AuthEndpoints/AuthEndpoints.csproj
+++ b/src/AuthEndpoints/AuthEndpoints.csproj
@@ -6,14 +6,14 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Description>Auth library that provides a set of minimal api endpoints to handle authentication actions</Description>
-    <Version>3.0.4</Version>
+    <Version>3.0.5</Version>
     <Authors>madeyoga</Authors>
     <Company>madeyoga</Company>
     <PackageProjectUrl>https://github.com/madeyoga/AuthEndpoints</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/madeyoga/AuthEndpoints</RepositoryUrl>
     <PackageTags>auth;endpoints;aspnetcore;jwt;passkey;webauthn;2fa;identity</PackageTags>
-    <PackageReleaseNotes>Optional IPasskeyUserIdFactory for the user id minted during passwordless passkey registration.</PackageReleaseNotes>
+    <PackageReleaseNotes>Passwordless passkey register sends a confirmation email after creating the account. Register only creates a new account (the attested user id must be new). Signed-in POST /passkeys/ still adds passkeys to existing accounts.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump AuthEndpoints `3.0.4` → `3.0.5` and add the changelog page.

Passwordless passkey register sends a confirmation email after creating the account. Register only creates a new account (the attested user id must be new). Signed-in `POST /passkeys/` still adds passkeys to existing accounts.

- AuthEndpoints `3.0.4` → `3.0.5`
- Docs changelog `v3.0.5` is Latest; `v3.0.4` no longer has that badge
- AuthEndpoints.External.OAuth remains `3.0.0-preview.3`

Does not create the GitHub release or tag. After merge, publish release `v3.0.5` to trigger NuGet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b76a35b8-3763-404d-9983-3370da3ff915?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b76a35b8-3763-404d-9983-3370da3ff915&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

