### PR TITLE
Bump AuthEndpoints to 3.0.6

### DIFF
--- a/Documentation/content/versions/v3.0.5.md
+++ b/Documentation/content/versions/v3.0.5.md
@@ -2,7 +2,6 @@
 title: v3.0.5
 description: Passwordless passkey register sends confirmation email; register creates only new accounts.
 date: 2026-09-06
-badge: Latest
 tag: v3.0.5
 ---
 

--- a/Documentation/content/versions/v3.0.6.md
+++ b/Documentation/content/versions/v3.0.6.md
@@ -1,0 +1,25 @@
+---
+title: v3.0.6
+description: Simple JWT refresh rotation is atomic under concurrent requests.
+date: 2026-09-07
+badge: Latest
+tag: v3.0.6
+---
+
+### AuthEndpoints
+
+Simple JWT refresh rotation is atomic under concurrent requests. Concurrent refresh calls against the same live refresh cookie complete with a single successor.
+
+- Simple JWT refresh rotation is atomic under concurrent requests
+- Concurrent refresh of a live cookie does not issue a second live refresh cookie
+
+### Packages
+
+- **AuthEndpoints** `3.0.6`
+- **AuthEndpoints.External.OAuth** unchanged at `3.0.0-preview.3`
+
+### Links
+
+- [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/v3.0.6)
+- [Compare](https://github.com/madeyoga/AuthEndpoints/compare/v3.0.5...v3.0.6)
+- [Installation](/getting-started/installation)

--- a/src/AuthEndpoints/AuthEndpoints.csproj
+++ b/src/AuthEndpoints/AuthEndpoints.csproj
@@ -6,14 +6,14 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Description>Auth library that provides a set of minimal api endpoints to handle authentication actions</Description>
-    <Version>3.0.5</Version>
+    <Version>3.0.6</Version>
     <Authors>madeyoga</Authors>
     <Company>madeyoga</Company>
     <PackageProjectUrl>https://github.com/madeyoga/AuthEndpoints</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/madeyoga/AuthEndpoints</RepositoryUrl>
     <PackageTags>auth;endpoints;aspnetcore;jwt;passkey;webauthn;2fa;identity</PackageTags>
-    <PackageReleaseNotes>Passwordless passkey register sends a confirmation email after creating the account. Register only creates a new account (the attested user id must be new). Signed-in POST /passkeys/ still adds passkeys to existing accounts.</PackageReleaseNotes>
+    <PackageReleaseNotes>Simple JWT refresh rotation is atomic under concurrent requests.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump AuthEndpoints `3.0.5` → `3.0.6` and add the changelog page.

Simple JWT refresh rotation is atomic under concurrent requests.

- AuthEndpoints `3.0.5` → `3.0.6`
- Docs changelog `v3.0.6` is Latest; `v3.0.5` no longer has that badge
- AuthEndpoints.External.OAuth remains `3.0.0-preview.3`

Does not create the GitHub release or tag. After merge, publish release `v3.0.6` to trigger NuGet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d96153f2-ec4b-47f2-a1a4-b71ac61c7e8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d96153f2-ec4b-47f2-a1a4-b71ac61c7e8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

