### PR TITLE
feat(identity): redirect confirm-email to SPA hosts

### DIFF
--- a/.cursor/skills/verify-authendpoints/SKILL.md
+++ b/.cursor/skills/verify-authendpoints/SKILL.md
@@ -61,6 +61,7 @@ Default `AE_HOST_MODE=compose`:
 Host defaults that **differ from production library defaults**:
 
 - `SignIn.RequireConfirmedAccount = false` (library facade default is **true**). Set `AE_REQUIRE_CONFIRMED_ACCOUNT=true` before `launch` to match the library default for confirmation-gated sign-in.
+- Confirm-email SPA redirect is unset. Set `AE_CONFIRM_EMAIL_REDIRECT_URI` (and `AE_CONFIRM_EMAIL_ALLOWED_ORIGINS` for an absolute URI) before `launch`. The launch whitelist passes both through `exec env`.
 - Password rules are relaxed (`RequiredLength = 6`, no digit/case/symbol requirements). Use `Passw0rd!`.
 - EF Core **SQLite** file under the temp directory (`TestDbName`). All users vanish when that file is removed; a new `AE_RUN_ID` uses a new file.
 - JWT signing key is the test-only value in `Program.cs`. Never treat it as a production secret.

--- a/.cursor/skills/verify-authendpoints/features/README.md
+++ b/.cursor/skills/verify-authendpoints/features/README.md
@@ -47,3 +47,4 @@ Each feature file starts with an H1 title and one paragraph. It then uses exactl
 - [Simple JWT](./simple-jwt.md) covers `/auth/create`, verify, and refresh-cookie refresh.
 - [ReAuth step-up](./reauth.md) covers `confirmIdentity` and a protected manage mutation.
 - [Passkeys](./passkeys.md) covers passwordless register/login, confirmation mail under `AE_REQUIRE_CONFIRMED_ACCOUNT=true`, and the test-only WebAuthn helper.
+- [Confirm email](./confirm-email.md) covers `GET /identity/confirmEmail` thank-you / 401 and the optional SPA redirect (`AE_CONFIRM_EMAIL_REDIRECT_URI`).

--- a/.cursor/skills/verify-authendpoints/features/confirm-email.md
+++ b/.cursor/skills/verify-authendpoints/features/confirm-email.md
@@ -1,0 +1,39 @@
+# Confirm email
+
+Browser `GET /identity/confirmEmail` confirms the account (or change-email) from the mailed link. Unset hosts return plain text or `401`. When `AE_CONFIRM_EMAIL_REDIRECT_URI` is set, the same GET returns `302` with `status` and `flow`.
+
+## Sub-features
+
+- `unset-success` returns `200` and `Thank you for confirming your email.`
+- `unset-failure` returns `401` for a bad code or unknown user
+- `redirect-success` returns `302` with `status=confirmed` and `flow=confirm` (or `change-email`)
+- `redirect-failure` returns `302` with `status=failed` and the same `flow`
+
+## How to get to it (user POV)
+
+- `POST /identity/register` JSON `{ "email", "password" }`
+- `GET /test/mailbox` lists captured mail. Confirmation `body` is the HTML-encoded confirm URL
+- `GET /identity/confirmEmail?userId=&code=` from that URL. Optional `changedEmail` uses the same route
+
+## Driving it with ae-http
+
+Preconditions:
+
+- Host is healthy (`ae-http.sh doctor`).
+- For redirect cases, launch with `AE_CONFIRM_EMAIL_REDIRECT_URI=/auth/email-confirmed`. For an absolute URI, also set `AE_CONFIRM_EMAIL_ALLOWED_ORIGINS`.
+- Cookie jar is empty.
+- `EMAIL` is unused.
+
+- **Register.** Run `ae-http.sh post /identity/register "{\"email\":\"${EMAIL}\",\"password\":\"${PASS}\"}" --out register`. Status is `200`.
+- **Mailbox.** Run `ae-http.sh get /test/mailbox --out mailbox`. Body contains a `confirm` item for `EMAIL` whose `body` includes `/identity/confirmEmail`.
+- **Confirm (unset host).** GET the HTML-decoded confirm URL. Status is `200`. Body contains `confirming`.
+- **Confirm (redirect host).** GET the same URL. Status is `302`. `Location` has `status=confirmed` and `flow=confirm`. Do not follow the redirect.
+- **Failure (redirect host).** GET `/identity/confirmEmail?userId=${USER_ID}&code=not-a-valid-code`. Status is `302`. `Location` has `status=failed` and `flow=confirm`.
+- **Proof.** Keep register, mailbox, and the confirm GET status plus headers (`Location` when redirected).
+
+## Gotchas
+
+- Confirmation links in the mailbox are HTML-encoded (`&amp;`). Decode before GET.
+- The harness `get` does not follow redirects. Read `Location` from `--out` headers.
+- Tokens, user ids, and emails are not added to the redirect query.
+- `/test/mailbox` is not a library route. Cite `/identity/confirmEmail` as the product proof.

--- a/.cursor/skills/verify-authendpoints/scripts/ae-http.sh
+++ b/.cursor/skills/verify-authendpoints/scripts/ae-http.sh
@@ -26,6 +26,8 @@ Environment:
   AE_HOST_MODE     Test host mapping: compose (default) or bearer-facade
   AE_REQUIRE_CONFIRMED_ACCOUNT  When true, the test host sets SignIn.RequireConfirmedAccount.
                                 Library default is true; this host defaults to false.
+  AE_CONFIRM_EMAIL_REDIRECT_URI  Maps to AuthEndpointsOptions.EmailConfirmation.ConfirmEmailRedirectUri.
+  AE_CONFIRM_EMAIL_ALLOWED_ORIGINS  Comma-separated AllowedRedirectOrigins.
 
 Examples:
   AE_RUN_ID=demo ./ae-http.sh launch
@@ -257,6 +259,8 @@ cmd_launch() {
       DOTNET_ENVIRONMENT=Development \
       AE_HOST_MODE="$AE_HOST_MODE" \
       AE_REQUIRE_CONFIRMED_ACCOUNT="${AE_REQUIRE_CONFIRMED_ACCOUNT:-}" \
+      AE_CONFIRM_EMAIL_REDIRECT_URI="${AE_CONFIRM_EMAIL_REDIRECT_URI:-}" \
+      AE_CONFIRM_EMAIL_ALLOWED_ORIGINS="${AE_CONFIRM_EMAIL_ALLOWED_ORIGINS:-}" \
       dotnet "$AE_DLL"
   ) >"$AE_LOG_FILE" 2>&1 &
   echo $! > "$AE_PID_FILE"

--- a/Documentation/content/1.getting-started/5.configuration.md
+++ b/Documentation/content/1.getting-started/5.configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Reference for AuthEndpointsOptions and nested passkey/JWT settings.
+description: Reference for AuthEndpointsOptions and nested passkey, JWT, and email confirmation settings.
 navigation:
   icon: i-lucide-settings
 ---
@@ -16,6 +16,7 @@ Configure the facade via `AddAuthEndpoints<TUser, TContext>(…)` or, with roles
 | `PasskeyPath` | `/account` | Route prefix for passkey endpoints |
 | `RequireConfirmedAccount` | `true` | Identity requires a confirmed account before sign-in |
 | `Passkeys` | (enabled) | Nested [passkey options](#passkeys) |
+| `EmailConfirmation` | (unset) | Nested [email confirmation](#email-confirmation) |
 | `Jwt` | (disabled) | Nested [JWT options](#jwt) |
 | `ConfigureIdentity` | `null` | Optional `Action<IdentityOptions>` applied after secure defaults |
 | `ConfigurePasskeys` | `null` | Optional `Action<IdentityPasskeyOptions>` after `ServerDomain` is applied |
@@ -29,6 +30,32 @@ Configure the facade via `AddAuthEndpoints<TUser, TContext>(…)` or, with roles
 | --- | --- | --- |
 | `Enabled` | `true` | When false, passkey DI and mapping are skipped |
 | `ServerDomain` | `null` | WebAuthn relying-party domain (e.g. `example.com`). **Required in Production** when enabled |
+
+## Email confirmation
+
+`AuthEndpointsEmailConfirmationOptions`:
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `ConfirmEmailRedirectUri` | `null` | After browser `GET` confirm-email, redirect here instead of the plain-text / 401 response. Absolute `https://` (or `http://` in Development), or a rooted path such as `/auth/email-confirmed`. |
+| `AllowedRedirectOrigins` | empty | Origins such as `https://app.example.com` required when the redirect URI is absolute. A rooted path does not need an entry. |
+
+URI rules:
+
+- Protocol-relative (`//…`) and non-http(s) schemes are rejected.
+- A rooted path is resolved against the request public origin (`scheme://host`, including port). `PathBase` is not included.
+- An absolute URI must match an allowlist entry on scheme, host, and optional port (origin only).
+- Absolute URI plus an empty allowlist is refused at request time. Production also fails options validation.
+- Absolute `http://` is refused unless the host is Development. Production fails options validation for `http://`.
+
+Every redirect overwrites (does not append) these query parameters:
+
+| Name | Values |
+| --- | --- |
+| `status` | `confirmed` or `failed` |
+| `flow` | `confirm` when `changedEmail` is absent; `change-email` when it is present |
+
+The redirect query does not include tokens, user ids, or emails.
 
 ## JWT
 

--- a/Documentation/content/3.modules/1.identity-management.md
+++ b/Documentation/content/3.modules/1.identity-management.md
@@ -48,6 +48,8 @@ Query string on `GET /confirmEmail`:
 | `code` | yes | Confirmation (or change-email) token from the emailed link |
 | `changedEmail` | no | When set, confirms a change to that email and updates the user name |
 
+When `AuthEndpointsOptions.EmailConfirmation.ConfirmEmailRedirectUri` is set, success and failure return `302` to that URI with `status` and `flow` instead of the thank-you body or `401`. The account mutation still runs first. Leave the option unset for callers that expect `200` or `401`. See [Configuration](/getting-started/configuration#email-confirmation).
+
 ### resendConfirmationEmail
 
 Requires a signed-in user (`RequireAuthorization` + CSRF). The request body `email` (`ResendConfirmationEmailRequest`) is ignored; the handler resends to the signed-in user's email.

--- a/src/AuthEndpoints/AuthEndpointsOptions.cs
+++ b/src/AuthEndpoints/AuthEndpointsOptions.cs
@@ -31,6 +31,9 @@ public sealed class AuthEndpointsOptions
     /// <summary>Passkey (WebAuthn) settings for the default bundle.</summary>
     public AuthEndpointsPasskeyOptions Passkeys { get; set; } = new();
 
+    /// <summary>SPA redirect after browser GET confirm-email.</summary>
+    public AuthEndpointsEmailConfirmationOptions EmailConfirmation { get; set; } = new();
+
     /// <summary>Optional JWT settings. Disabled by default; enable for facade JWT mapping.</summary>
     public AuthEndpointsJwtOptions Jwt { get; set; } = new();
 
@@ -58,6 +61,22 @@ public sealed class AuthEndpointsPasskeyOptions
     /// Required in Production when <see cref="Enabled"/> is true.
     /// </summary>
     public string? ServerDomain { get; set; }
+}
+
+/// <summary>Email confirmation redirect settings for SPA hosts.</summary>
+public sealed class AuthEndpointsEmailConfirmationOptions
+{
+    /// <summary>
+    /// Frontend URI after <c>GET</c> confirm-email (absolute <c>https://</c>, or a rooted path).
+    /// Empty or null keeps the plain-text / 401 response.
+    /// </summary>
+    public string? ConfirmEmailRedirectUri { get; set; }
+
+    /// <summary>
+    /// Origins such as <c>https://app.example.com</c> allowed for an absolute <see cref="ConfirmEmailRedirectUri"/>.
+    /// A rooted path does not need an entry.
+    /// </summary>
+    public IList<string> AllowedRedirectOrigins { get; set; } = new List<string>();
 }
 
 /// <summary>JWT-related options for the opinionated facade.</summary>

--- a/src/AuthEndpoints/AuthEndpointsOptionsValidator.cs
+++ b/src/AuthEndpoints/AuthEndpointsOptionsValidator.cs
@@ -1,3 +1,4 @@
+using AuthEndpoints.Identity;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -40,6 +41,52 @@ internal sealed class AuthEndpointsOptionsValidator : IValidateOptions<AuthEndpo
             && (string.IsNullOrWhiteSpace(options.Jwt.Path) || !options.Jwt.Path.StartsWith('/')))
         {
             return ValidateOptionsResult.Fail("AuthEndpoints: Jwt.Path must be a rooted path (e.g. \"/auth\").");
+        }
+
+        ValidateOptionsResult emailConfirmation = ValidateEmailConfirmation(options.EmailConfirmation);
+        if (emailConfirmation.Failed)
+        {
+            return emailConfirmation;
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+
+    private ValidateOptionsResult ValidateEmailConfirmation(AuthEndpointsEmailConfirmationOptions emailConfirmation)
+    {
+        if (ConfirmEmailRedirect.IsIllegal(emailConfirmation.ConfirmEmailRedirectUri))
+        {
+            return ValidateOptionsResult.Fail(
+                "AuthEndpoints: EmailConfirmation.ConfirmEmailRedirectUri must be a rooted path or an absolute http(s) URI.");
+        }
+
+        if (!ConfirmEmailRedirect.TryGetAbsolute(emailConfirmation.ConfirmEmailRedirectUri, out Uri absolute))
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        if (!_environment.IsProduction())
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        if (string.Equals(absolute.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidateOptionsResult.Fail(
+                "AuthEndpoints: EmailConfirmation.ConfirmEmailRedirectUri must use https in Production.");
+        }
+
+        IReadOnlyList<string> allowed = ConfirmEmailRedirect.AsReadOnlyOrigins(emailConfirmation.AllowedRedirectOrigins);
+        if (allowed.Count == 0)
+        {
+            return ValidateOptionsResult.Fail(
+                "AuthEndpoints: EmailConfirmation.AllowedRedirectOrigins must be set in Production when ConfirmEmailRedirectUri is an absolute URI.");
+        }
+
+        if (!ConfirmEmailRedirect.IsOriginAllowlisted(absolute, allowed))
+        {
+            return ValidateOptionsResult.Fail(
+                "AuthEndpoints: EmailConfirmation.ConfirmEmailRedirectUri origin must match an AllowedRedirectOrigins entry.");
         }
 
         return ValidateOptionsResult.Success;

--- a/src/AuthEndpoints/Identity/ConfirmEmailRedirect.cs
+++ b/src/AuthEndpoints/Identity/ConfirmEmailRedirect.cs
@@ -1,0 +1,181 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
+
+namespace AuthEndpoints.Identity;
+
+internal static class ConfirmEmailRedirect
+{
+    public static string? TryResolve(
+        string? configuredUri,
+        IReadOnlyList<string> allowedOrigins,
+        bool allowHttp,
+        string requestScheme,
+        HostString requestHost)
+    {
+        Kind kind = Inspect(configuredUri, out string trimmed, out Uri? absolute);
+        return kind switch
+        {
+            Kind.RootedPath => ResolveRootedPath(trimmed, requestScheme, requestHost),
+            Kind.Absolute => ResolveAbsolute(absolute!, allowedOrigins, allowHttp),
+            _ => null
+        };
+    }
+
+    public static string WithQuery(string uri, bool succeeded, bool isChangeEmail)
+    {
+        var parsed = new Uri(uri, UriKind.Absolute);
+        Dictionary<string, StringValues> existing = QueryHelpers.ParseQuery(parsed.Query);
+        var pairs = new List<KeyValuePair<string, string?>>();
+
+        foreach (KeyValuePair<string, StringValues> pair in existing)
+        {
+            if (pair.Key.Equals("status", StringComparison.OrdinalIgnoreCase)
+                || pair.Key.Equals("flow", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (string? value in pair.Value)
+            {
+                pairs.Add(new KeyValuePair<string, string?>(pair.Key, value));
+            }
+        }
+
+        pairs.Add(new KeyValuePair<string, string?>("status", succeeded ? "confirmed" : "failed"));
+        pairs.Add(new KeyValuePair<string, string?>("flow", isChangeEmail ? "change-email" : "confirm"));
+
+        var builder = new UriBuilder(parsed)
+        {
+            Query = QueryString.Create(pairs).ToString().TrimStart('?')
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    internal static bool IsIllegal(string? configuredUri) =>
+        Inspect(configuredUri, out _, out _) == Kind.Illegal;
+
+    internal static bool TryGetAbsolute(string? configuredUri, out Uri absolute)
+    {
+        if (Inspect(configuredUri, out _, out Uri? uri) == Kind.Absolute)
+        {
+            absolute = uri!;
+            return true;
+        }
+
+        absolute = null!;
+        return false;
+    }
+
+    internal static bool IsOriginAllowlisted(Uri absolute, IReadOnlyList<string> allowedOrigins)
+    {
+        for (int i = 0; i < allowedOrigins.Count; i++)
+        {
+            string candidate = allowedOrigins[i];
+            if (string.IsNullOrWhiteSpace(candidate)
+                || !Uri.TryCreate(candidate.Trim(), UriKind.Absolute, out Uri? allowed))
+            {
+                continue;
+            }
+
+            if (string.Equals(absolute.Scheme, allowed.Scheme, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(absolute.Host, allowed.Host, StringComparison.OrdinalIgnoreCase)
+                && absolute.Port == allowed.Port)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static IReadOnlyList<string> AsReadOnlyOrigins(IList<string> origins) =>
+        origins as IReadOnlyList<string> ?? origins.ToList();
+
+    private enum Kind
+    {
+        Unset,
+        RootedPath,
+        Absolute,
+        Illegal
+    }
+
+    private static Kind Inspect(string? configuredUri, out string trimmed, out Uri? absolute)
+    {
+        trimmed = configuredUri?.Trim() ?? string.Empty;
+        absolute = null;
+
+        if (trimmed.Length == 0)
+        {
+            return Kind.Unset;
+        }
+
+        if (trimmed.StartsWith("//", StringComparison.Ordinal))
+        {
+            return Kind.Illegal;
+        }
+
+        if (IsRootedPath(trimmed))
+        {
+            return Kind.RootedPath;
+        }
+
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out Uri? uri)
+            && (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            && !string.IsNullOrEmpty(uri.Host))
+        {
+            absolute = uri;
+            return Kind.Absolute;
+        }
+
+        return Kind.Illegal;
+    }
+
+    private static bool IsRootedPath(string value)
+    {
+        if (value[0] != '/')
+        {
+            return false;
+        }
+
+        if (value.Length == 1)
+        {
+            return true;
+        }
+
+        return value[1] != '/' && value[1] != '\\';
+    }
+
+    private static string? ResolveRootedPath(string path, string requestScheme, HostString requestHost)
+    {
+        if (string.IsNullOrWhiteSpace(requestScheme) || !requestHost.HasValue)
+        {
+            return null;
+        }
+
+        string origin = $"{requestScheme}://{requestHost}";
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out Uri? originUri))
+        {
+            return null;
+        }
+
+        return new Uri(originUri, path).AbsoluteUri;
+    }
+
+    private static string? ResolveAbsolute(Uri absolute, IReadOnlyList<string> allowedOrigins, bool allowHttp)
+    {
+        if (string.Equals(absolute.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) && !allowHttp)
+        {
+            return null;
+        }
+
+        if (allowedOrigins.Count == 0 || !IsOriginAllowlisted(absolute, allowedOrigins))
+        {
+            return null;
+        }
+
+        return absolute.AbsoluteUri;
+    }
+}

--- a/src/AuthEndpoints/Identity/IdentityApiEndpoints.cs
+++ b/src/AuthEndpoints/Identity/IdentityApiEndpoints.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
+using AuthEndpoints;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication.BearerToken;
 using Microsoft.AspNetCore.Http;
@@ -16,6 +17,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace AuthEndpoints.Identity;
@@ -183,17 +185,21 @@ public class IdentityApiEndpoints<TUser>
         return Results.Ok(new { CsrfToken = tokens.RequestToken });
     }
 
-    public static async Task<Results<ContentHttpResult, UnauthorizedHttpResult>> ConfirmEmail(
+    public static async Task<Results<ContentHttpResult, UnauthorizedHttpResult, RedirectHttpResult>> ConfirmEmail(
         [FromQuery] string userId,
         [FromQuery] string code,
         [FromQuery] string? changedEmail,
+        HttpContext context,
         [FromServices] IServiceProvider sp)
     {
+        string? redirect = TryResolveConfirmEmailRedirect(sp, context);
+        bool isChangeEmail = !string.IsNullOrEmpty(changedEmail);
+
         var userManager = sp.GetRequiredService<UserManager<TUser>>();
         if (await userManager.FindByIdAsync(userId) is not { } user)
         {
             // We could respond with a 404 instead of a 401 like Identity UI, but that feels like unnecessary information.
-            return TypedResults.Unauthorized();
+            return ConfirmEmailFailure(redirect, isChangeEmail);
         }
 
         try
@@ -202,7 +208,7 @@ public class IdentityApiEndpoints<TUser>
         }
         catch (FormatException)
         {
-            return TypedResults.Unauthorized();
+            return ConfirmEmailFailure(redirect, isChangeEmail);
         }
 
         IdentityResult result;
@@ -225,10 +231,44 @@ public class IdentityApiEndpoints<TUser>
 
         if (!result.Succeeded)
         {
-            return TypedResults.Unauthorized();
+            return ConfirmEmailFailure(redirect, isChangeEmail);
+        }
+
+        if (redirect is not null)
+        {
+            return TypedResults.Redirect(ConfirmEmailRedirect.WithQuery(redirect, succeeded: true, isChangeEmail));
         }
 
         return TypedResults.Text("Thank you for confirming your email.");
+    }
+
+    private static string? TryResolveConfirmEmailRedirect(IServiceProvider sp, HttpContext context)
+    {
+        AuthEndpointsOptions? options = sp.GetService<IOptions<AuthEndpointsOptions>>()?.Value;
+        if (options is null)
+        {
+            return null;
+        }
+
+        bool allowHttp = sp.GetService<IHostEnvironment>()?.IsDevelopment() == true;
+        return ConfirmEmailRedirect.TryResolve(
+            options.EmailConfirmation.ConfirmEmailRedirectUri,
+            ConfirmEmailRedirect.AsReadOnlyOrigins(options.EmailConfirmation.AllowedRedirectOrigins),
+            allowHttp,
+            context.Request.Scheme,
+            context.Request.Host);
+    }
+
+    private static Results<ContentHttpResult, UnauthorizedHttpResult, RedirectHttpResult> ConfirmEmailFailure(
+        string? redirect,
+        bool isChangeEmail)
+    {
+        if (redirect is not null)
+        {
+            return TypedResults.Redirect(ConfirmEmailRedirect.WithQuery(redirect, succeeded: false, isChangeEmail));
+        }
+
+        return TypedResults.Unauthorized();
     }
 
     public static async Task<Ok> ResendConfirmationEmail(

--- a/tests/AuthEndpoints.Tests/AuthEndpointsFacadeTests.cs
+++ b/tests/AuthEndpoints.Tests/AuthEndpointsFacadeTests.cs
@@ -110,6 +110,33 @@ public class AuthEndpointsFacadeTests
     }
 
     [Fact]
+    public void Facade_Production_AbsoluteConfirmEmailRedirectWithoutAllowlist_FailsValidation()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddDbContext<TestDbContext>(o =>
+            o.UseInMemoryDatabase("FacadeProdConfirmRedirect_" + Guid.NewGuid().ToString("N")));
+        builder.Services.AddAuthEndpoints<TestAppUser, TestDbContext>(o =>
+        {
+            o.Passkeys.ServerDomain = "example.com";
+            o.RequireEmailSenderInProduction = false;
+            o.EmailConfirmation.ConfirmEmailRedirectUri = "https://spa.example.com/confirmed";
+        });
+        builder.Services.AddTransient<IEmailSender<TestAppUser>, TestEmailSender>();
+
+        using var app = builder.Build();
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+        {
+            _ = app.Services.GetRequiredService<IOptions<AuthEndpointsOptions>>().Value;
+        });
+        Assert.Contains("AllowedRedirectOrigins", ex.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Facade_Options_DefaultPaths()
     {
         var options = new AuthEndpointsOptions();
@@ -121,6 +148,8 @@ public class AuthEndpointsFacadeTests
         Assert.False(options.Jwt.Enabled);
         Assert.Equal("/auth", options.Jwt.Path);
         Assert.Equal(AuthEndpointsSignIn.Cookie, options.SignIn);
+        Assert.Null(options.EmailConfirmation.ConfirmEmailRedirectUri);
+        Assert.Empty(options.EmailConfirmation.AllowedRedirectOrigins);
     }
 
     [Fact]

--- a/tests/AuthEndpoints.Tests/ConfirmEmailRedirectEndpointsTests.cs
+++ b/tests/AuthEndpoints.Tests/ConfirmEmailRedirectEndpointsTests.cs
@@ -1,0 +1,187 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace AuthEndpoints.Tests;
+
+public class ConfirmEmailRedirectEndpointsTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public ConfirmEmailRedirectEndpointsTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Unset_ValidCode_ReturnsThankYou()
+    {
+        var email = $"confirm-unset-{Guid.NewGuid():N}@test.local";
+        var user = await TestHelpers.SeedUserAsync(_factory, email, emailConfirmed: false);
+        var code = await TestHelpers.GenerateEmailConfirmationCodeAsync(_factory, user);
+        using var client = TestHelpers.CreateClientWithCookies(_factory);
+
+        var response = await client.GetAsync(ConfirmPath(user.Id, code));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(response.Headers.Location);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Thank you for confirming your email.", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Unset_BadCode_ReturnsUnauthorized()
+    {
+        var email = $"confirm-unset-bad-{Guid.NewGuid():N}@test.local";
+        var user = await TestHelpers.SeedUserAsync(_factory, email, emailConfirmed: false);
+        using var client = TestHelpers.CreateClientWithCookies(_factory);
+
+        var response = await client.GetAsync(ConfirmPath(user.Id, "not-a-valid-code"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Null(response.Headers.Location);
+    }
+
+    [Fact]
+    public async Task RootedPath_Success_RedirectsConfirmedConfirm()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactory("/auth/email-confirmed");
+        var email = $"confirm-root-ok-{Guid.NewGuid():N}@test.local";
+        var user = await TestHelpers.SeedUserAsync(factory, email, emailConfirmed: false);
+        var code = await TestHelpers.GenerateEmailConfirmationCodeAsync(factory, user);
+        using var client = TestHelpers.CreateClientWithCookies(factory);
+
+        var response = await client.GetAsync(ConfirmPath(user.Id, code));
+
+        Uri location = RequireRedirectLocation(response);
+        Assert.Equal("/auth/email-confirmed", location.AbsolutePath);
+        AssertStatusAndFlow(location, "confirmed", "confirm");
+
+        var confirmed = await TestHelpers.FindUserByEmailAsync(factory, email);
+        Assert.NotNull(confirmed);
+        Assert.True(confirmed.EmailConfirmed);
+    }
+
+    [Fact]
+    public async Task RootedPath_Failure_RedirectsFailedConfirm()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactory("/auth/email-confirmed");
+        var email = $"confirm-root-fail-{Guid.NewGuid():N}@test.local";
+        var user = await TestHelpers.SeedUserAsync(factory, email, emailConfirmed: false);
+        using var client = TestHelpers.CreateClientWithCookies(factory);
+
+        var response = await client.GetAsync(ConfirmPath(user.Id, "not-a-valid-code"));
+
+        Uri location = RequireRedirectLocation(response);
+        Assert.Equal("/auth/email-confirmed", location.AbsolutePath);
+        AssertStatusAndFlow(location, "failed", "confirm");
+
+        var unchanged = await TestHelpers.FindUserByEmailAsync(factory, email);
+        Assert.NotNull(unchanged);
+        Assert.False(unchanged.EmailConfirmed);
+    }
+
+    [Fact]
+    public async Task AbsoluteAllowlisted_Success_RedirectsOriginStatusAndFlow()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactory(
+            "https://spa.example.com/auth/email-confirmed",
+            "https://spa.example.com");
+        var email = $"confirm-abs-ok-{Guid.NewGuid():N}@test.local";
+        var user = await TestHelpers.SeedUserAsync(factory, email, emailConfirmed: false);
+        var code = await TestHelpers.GenerateEmailConfirmationCodeAsync(factory, user);
+        using var client = TestHelpers.CreateClientWithCookies(factory);
+
+        var response = await client.GetAsync(ConfirmPath(user.Id, code));
+
+        Uri location = RequireRedirectLocation(response);
+        Assert.Equal("https", location.Scheme);
+        Assert.Equal("spa.example.com", location.Host);
+        Assert.Equal("/auth/email-confirmed", location.AbsolutePath);
+        AssertStatusAndFlow(location, "confirmed", "confirm");
+    }
+
+    [Fact]
+    public async Task AbsoluteNotAllowlisted_RefusesRedirect_KeepsThankYou()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactory(
+            "https://spa.example.com/auth/email-confirmed",
+            "https://other.example.com");
+        var email = $"confirm-abs-refuse-{Guid.NewGuid():N}@test.local";
+        var user = await TestHelpers.SeedUserAsync(factory, email, emailConfirmed: false);
+        var code = await TestHelpers.GenerateEmailConfirmationCodeAsync(factory, user);
+        using var client = TestHelpers.CreateClientWithCookies(factory);
+
+        var response = await client.GetAsync(ConfirmPath(user.Id, code));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(response.Headers.Location);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Thank you for confirming your email.", body, StringComparison.Ordinal);
+
+        var confirmed = await TestHelpers.FindUserByEmailAsync(factory, email);
+        Assert.NotNull(confirmed);
+        Assert.True(confirmed.EmailConfirmed);
+    }
+
+    [Fact]
+    public async Task ChangeEmail_Success_RedirectsChangeEmailConfirmed()
+    {
+        using WebApplicationFactory<Program> factory = CreateFactory("/auth/email-confirmed");
+        var email = $"confirm-change-{Guid.NewGuid():N}@test.local";
+        var newEmail = $"confirm-changed-{Guid.NewGuid():N}@test.local";
+        var user = await TestHelpers.SeedUserAsync(factory, email);
+        var code = await TestHelpers.GenerateChangeEmailCodeAsync(factory, user, newEmail);
+        using var client = TestHelpers.CreateClientWithCookies(factory);
+
+        var response = await client.GetAsync(
+            $"/identity/confirmEmail?userId={Uri.EscapeDataString(user.Id)}&code={Uri.EscapeDataString(code)}&changedEmail={Uri.EscapeDataString(newEmail)}");
+
+        Uri location = RequireRedirectLocation(response);
+        AssertStatusAndFlow(location, "confirmed", "change-email");
+
+        var changed = await TestHelpers.FindUserByEmailAsync(factory, newEmail);
+        Assert.NotNull(changed);
+        Assert.Equal(newEmail, changed.Email);
+        Assert.True(changed.EmailConfirmed);
+    }
+
+    private WebApplicationFactory<Program> CreateFactory(string redirectUri, string? allowedOrigins = null)
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("TestDbName", "ConfirmEmailRedirect_" + Guid.NewGuid().ToString("N"));
+            builder.UseSetting("AE_CONFIRM_EMAIL_REDIRECT_URI", redirectUri);
+            if (allowedOrigins is not null)
+            {
+                builder.UseSetting("AE_CONFIRM_EMAIL_ALLOWED_ORIGINS", allowedOrigins);
+            }
+        });
+    }
+
+    private static string ConfirmPath(string userId, string code) =>
+        $"/identity/confirmEmail?userId={Uri.EscapeDataString(userId)}&code={Uri.EscapeDataString(code)}";
+
+    private static Uri RequireRedirectLocation(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+        Uri location = response.Headers.Location;
+        if (!location.IsAbsoluteUri)
+        {
+            location = new Uri(new Uri("http://localhost"), location);
+        }
+
+        return location;
+    }
+
+    private static void AssertStatusAndFlow(Uri location, string status, string flow)
+    {
+        var query = QueryHelpers.ParseQuery(location.Query);
+        Assert.Equal(status, (string?)query["status"]);
+        Assert.Equal(flow, (string?)query["flow"]);
+        Assert.False(query.ContainsKey("userId"));
+        Assert.False(query.ContainsKey("code"));
+        Assert.False(query.ContainsKey("email"));
+    }
+}

--- a/tests/AuthEndpoints.Tests/ConfirmEmailRedirectTests.cs
+++ b/tests/AuthEndpoints.Tests/ConfirmEmailRedirectTests.cs
@@ -1,0 +1,138 @@
+using AuthEndpoints.Identity;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace AuthEndpoints.Tests;
+
+public class ConfirmEmailRedirectTests
+{
+    private static readonly HostString LocalHost = new("localhost");
+    private static readonly string[] SpaOrigin = ["https://spa.example.com"];
+
+    [Fact]
+    public void TryResolve_Unset_ReturnsNull()
+    {
+        Assert.Null(ConfirmEmailRedirect.TryResolve(null, SpaOrigin, allowHttp: true, "https", LocalHost));
+        Assert.Null(ConfirmEmailRedirect.TryResolve("  ", SpaOrigin, allowHttp: true, "https", LocalHost));
+    }
+
+    [Fact]
+    public void TryResolve_RootedPath_ResolvesAgainstRequestOrigin()
+    {
+        string? resolved = ConfirmEmailRedirect.TryResolve(
+            "/auth/email-confirmed",
+            Array.Empty<string>(),
+            allowHttp: false,
+            "https",
+            new HostString("api.example.com:8443"));
+
+        Assert.Equal("https://api.example.com:8443/auth/email-confirmed", resolved);
+    }
+
+    [Fact]
+    public void TryResolve_AbsoluteAllowlistedHttps_ReturnsUri()
+    {
+        string? resolved = ConfirmEmailRedirect.TryResolve(
+            "https://spa.example.com/auth/email-confirmed",
+            SpaOrigin,
+            allowHttp: false,
+            "http",
+            LocalHost);
+
+        Assert.NotNull(resolved);
+        var uri = new Uri(resolved);
+        Assert.Equal("https", uri.Scheme);
+        Assert.Equal("spa.example.com", uri.Host);
+        Assert.Equal("/auth/email-confirmed", uri.AbsolutePath);
+    }
+
+    [Fact]
+    public void TryResolve_HttpAbsolute_AllowedOnlyWhenAllowHttp()
+    {
+        string[] httpOrigin = ["http://spa.example.com"];
+        const string configured = "http://spa.example.com/done";
+
+        Assert.Null(ConfirmEmailRedirect.TryResolve(configured, httpOrigin, allowHttp: false, "https", LocalHost));
+
+        string? allowed = ConfirmEmailRedirect.TryResolve(configured, httpOrigin, allowHttp: true, "https", LocalHost);
+        Assert.NotNull(allowed);
+        Assert.Equal("http://spa.example.com/done", new Uri(allowed).GetLeftPart(UriPartial.Path).TrimEnd('/'));
+    }
+
+    [Fact]
+    public void TryResolve_ProtocolRelative_ReturnsNull()
+    {
+        Assert.Null(ConfirmEmailRedirect.TryResolve(
+            "//evil.example/x",
+            ["https://evil.example"],
+            allowHttp: true,
+            "https",
+            LocalHost));
+    }
+
+    [Fact]
+    public void TryResolve_NonHttp_ReturnsNull()
+    {
+        Assert.Null(ConfirmEmailRedirect.TryResolve("javascript:alert(1)", Array.Empty<string>(), allowHttp: true, "https", LocalHost));
+        Assert.Null(ConfirmEmailRedirect.TryResolve(
+            "ftp://files.example/x",
+            ["ftp://files.example"],
+            allowHttp: true,
+            "https",
+            LocalHost));
+    }
+
+    [Fact]
+    public void TryResolve_AbsoluteEmptyAllowlist_ReturnsNull()
+    {
+        Assert.Null(ConfirmEmailRedirect.TryResolve(
+            "https://spa.example.com/done",
+            Array.Empty<string>(),
+            allowHttp: true,
+            "https",
+            LocalHost));
+    }
+
+    [Fact]
+    public void TryResolve_OriginMismatch_ReturnsNull()
+    {
+        Assert.Null(ConfirmEmailRedirect.TryResolve(
+            "https://other.example/done",
+            SpaOrigin,
+            allowHttp: true,
+            "https",
+            LocalHost));
+    }
+
+    [Fact]
+    public void WithQuery_OverwritesStatusAndFlow()
+    {
+        string result = ConfirmEmailRedirect.WithQuery(
+            "https://spa.example.com/done?status=old&flow=old&keep=1",
+            succeeded: true,
+            isChangeEmail: false);
+
+        var query = QueryHelpers.ParseQuery(new Uri(result).Query);
+        Assert.Equal("confirmed", (string?)query["status"]);
+        Assert.Equal("confirm", (string?)query["flow"]);
+        Assert.Equal("1", (string?)query["keep"]);
+        Assert.Equal(1, query["status"].Count);
+        Assert.Equal(1, query["flow"].Count);
+    }
+
+    [Fact]
+    public void WithQuery_DoesNotAddUserIdCodeOrEmail()
+    {
+        string result = ConfirmEmailRedirect.WithQuery(
+            "https://spa.example.com/done",
+            succeeded: false,
+            isChangeEmail: true);
+
+        var query = QueryHelpers.ParseQuery(new Uri(result).Query);
+        Assert.Equal("failed", (string?)query["status"]);
+        Assert.Equal("change-email", (string?)query["flow"]);
+        Assert.False(query.ContainsKey("userId"));
+        Assert.False(query.ContainsKey("code"));
+        Assert.False(query.ContainsKey("email"));
+    }
+}

--- a/tests/AuthEndpoints.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/AuthEndpoints.Tests/Infrastructure/TestHelpers.cs
@@ -16,7 +16,7 @@ internal static class TestHelpers
     public const string DefaultPassword = "Passw0rd!";
 
     public static async Task<TestAppUser> SeedUserAsync(
-        TestWebApplicationFactory factory,
+        WebApplicationFactory<Program> factory,
         string email = "user@test.local",
         string password = DefaultPassword,
         bool twoFactorEnabled = false,
@@ -239,7 +239,7 @@ internal static class TestHelpers
     }
 
     public static async Task<string> GenerateEmailConfirmationCodeAsync(
-        TestWebApplicationFactory factory,
+        WebApplicationFactory<Program> factory,
         TestAppUser user)
     {
         using var scope = factory.Services.CreateScope();
@@ -247,6 +247,19 @@ internal static class TestHelpers
         var tracked = await userManager.FindByIdAsync(user.Id)
             ?? throw new InvalidOperationException($"User {user.Id} not found.");
         var code = await userManager.GenerateEmailConfirmationTokenAsync(tracked);
+        return WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+    }
+
+    public static async Task<string> GenerateChangeEmailCodeAsync(
+        WebApplicationFactory<Program> factory,
+        TestAppUser user,
+        string newEmail)
+    {
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<TestAppUser>>();
+        var tracked = await userManager.FindByIdAsync(user.Id)
+            ?? throw new InvalidOperationException($"User {user.Id} not found.");
+        var code = await userManager.GenerateChangeEmailTokenAsync(tracked, newEmail);
         return WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
     }
 
@@ -320,7 +333,7 @@ internal static class TestHelpers
     }
 
     public static async Task<TestAppUser?> FindUserByEmailAsync(
-        TestWebApplicationFactory factory,
+        WebApplicationFactory<Program> factory,
         string email)
     {
         using var scope = factory.Services.CreateScope();

--- a/tests/AuthEndpoints.Tests/Infrastructure/TestWebApplicationFactory.cs
+++ b/tests/AuthEndpoints.Tests/Infrastructure/TestWebApplicationFactory.cs
@@ -13,12 +13,16 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
         // UseSetting is applied early enough for WebApplication.CreateBuilder config reads.
         builder.UseSetting("TestDbName", _dbName);
         builder.UseSetting("AE_REQUIRE_CONFIRMED_ACCOUNT", "false");
+        builder.UseSetting("AE_CONFIRM_EMAIL_REDIRECT_URI", "");
+        builder.UseSetting("AE_CONFIRM_EMAIL_ALLOWED_ORIGINS", "");
         builder.ConfigureAppConfiguration((_, config) =>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["TestDbName"] = _dbName,
-                ["AE_REQUIRE_CONFIRMED_ACCOUNT"] = "false"
+                ["AE_REQUIRE_CONFIRMED_ACCOUNT"] = "false",
+                ["AE_CONFIRM_EMAIL_REDIRECT_URI"] = "",
+                ["AE_CONFIRM_EMAIL_ALLOWED_ORIGINS"] = ""
             });
         });
     }

--- a/tests/AuthEndpoints.Tests/Program.cs
+++ b/tests/AuthEndpoints.Tests/Program.cs
@@ -15,6 +15,8 @@ var dbName = builder.Configuration["TestDbName"] ?? "AuthEndpointsTests";
 var hostMode = builder.Configuration["AE_HOST_MODE"] ?? "compose";
 var useBearerFacade = string.Equals(hostMode, "bearer-facade", StringComparison.OrdinalIgnoreCase);
 var requireConfirmedAccount = IsTruthy(builder.Configuration["AE_REQUIRE_CONFIRMED_ACCOUNT"]);
+var confirmEmailRedirectUri = builder.Configuration["AE_CONFIRM_EMAIL_REDIRECT_URI"];
+var confirmEmailAllowedOrigins = SplitCommaSeparated(builder.Configuration["AE_CONFIRM_EMAIL_ALLOWED_ORIGINS"]);
 var dbPath = Path.Combine(Path.GetTempPath(), $"AuthEndpointsTests-{dbName}.sqlite");
 
 builder.Services.AddDbContext<TestDbContext>(options =>
@@ -38,6 +40,7 @@ if (useBearerFacade)
             {
                 jwt.SigningOptions.SymmetricKey = "TestOnly_AuthEndpoints_Jwt_SigningKey_32chars!";
             };
+            ApplyEmailConfirmation(o, confirmEmailRedirectUri, confirmEmailAllowedOrigins);
         });
 }
 else
@@ -56,6 +59,8 @@ else
     builder.Services.AddAntiforgery();
     builder.Services.AddCookieAuthEndpoints();
     builder.Services.AddPasskeyEndpoints<TestAppUser>();
+    builder.Services.AddOptions<AuthEndpointsOptions>()
+        .Configure(o => ApplyEmailConfirmation(o, confirmEmailRedirectUri, confirmEmailAllowedOrigins));
 }
 
 var app = builder.Build();
@@ -101,6 +106,32 @@ app.Run();
 static bool IsTruthy(string? value) =>
     string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
     || string.Equals(value, "1", StringComparison.OrdinalIgnoreCase);
+
+static void ApplyEmailConfirmation(
+    AuthEndpointsOptions options,
+    string? redirectUri,
+    IReadOnlyList<string> allowedOrigins)
+{
+    if (!string.IsNullOrWhiteSpace(redirectUri))
+    {
+        options.EmailConfirmation.ConfirmEmailRedirectUri = redirectUri;
+    }
+
+    if (allowedOrigins.Count > 0)
+    {
+        options.EmailConfirmation.AllowedRedirectOrigins = allowedOrigins.ToList();
+    }
+}
+
+static List<string> SplitCommaSeparated(string? value)
+{
+    if (string.IsNullOrWhiteSpace(value))
+    {
+        return [];
+    }
+
+    return [.. value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+}
 
 static void ConfigureTestIdentity(IdentityOptions options, bool requireConfirmedAccount)
 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

SPA hosts that require a confirmed account send users to a check-your-email page after register. Today `GET /identity/confirmEmail` returns a plain-text thank-you or `401`. Hosts need that browser GET to land on a frontend route with a success or failure signal.

This implements #253.

## Scope

- Nested `AuthEndpointsOptions.EmailConfirmation` with `ConfirmEmailRedirectUri` and `AllowedRedirectOrigins`.
- `IdentityApiEndpoints.ConfirmEmail` (facade and `MapIdentityManagementApi` share this handler) returns `302` with `status` and `flow` when the URI resolves, otherwise keeps `200` text / `401`.
- URI parse, allowlist, and query stamping live in `ConfirmEmailRedirect`. Protocol-relative and non-http(s) URIs are rejected. Rooted paths resolve against the request public origin. Absolute URIs must match the allowlist origin (scheme, host, port). Production fails options validation for an absolute URI with an empty allowlist.
- Query params on every redirect: `status=confirmed|failed`, `flow=confirm|change-email`. Tokens, user ids, and emails are not added.
- Test host env: `AE_CONFIRM_EMAIL_REDIRECT_URI`, `AE_CONFIRM_EMAIL_ALLOWED_ORIGINS`.
- Docs: configuration and identity-management confirmEmail notes. Verify skill feature map for confirm-email.

Out of scope: sign-in inside confirmEmail, public resend, passkey register mail, NuGet version bump.

## Tradeoffs

Request-time refuse (keep text / `401`) is the safety net when a compose host has no facade validator, or when Development starts with an absolute URI and an empty allowlist. Production facade hosts still fail at startup for that case.

## Blast Radius

Hosts that leave `ConfirmEmailRedirectUri` unset see no behavior change. Hosts that set it get `302` instead of `200`/`401` on the same GET. OpenAPI for confirm-email now includes a redirect result.

## Verification

`dotnet test tests/AuthEndpoints.Tests/AuthEndpoints.Tests.csproj`:

```
Passed!  - Failed:     0, Passed:   113, Skipped:     0, Total:   113
```

New coverage includes unset `200`/`401`, rooted-path and absolute allowlisted `302` with `status`/`flow`, allowlist refusal, change-email `flow=change-email`, and Production validation for an absolute URI with an empty allowlist.

Live compose host via `.cursor/skills/verify-authendpoints/scripts/ae-http.sh` (register, mailbox, `GET /identity/confirmEmail`, no redirect follow):

Unset host:

```
confirm.status=200
confirm.body=Thank you for confirming your email.
confirm-bad.status=401
```

Rooted path `AE_CONFIRM_EMAIL_REDIRECT_URI=/auth/email-confirmed`:

```
confirm.status=302
Location: http://127.0.0.1:5289/auth/email-confirmed?status=confirmed&flow=confirm
confirm-bad.status=302
Location: http://127.0.0.1:5289/auth/email-confirmed?status=failed&flow=confirm
```

Absolute allowlisted `https://spa.example.com`:

```
confirm.status=302
Location: https://spa.example.com/auth/email-confirmed?status=confirmed&flow=confirm
```

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9b07bfd-8dc9-417a-bfa9-91130c40b379?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9b07bfd-8dc9-417a-bfa9-91130c40b379&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

