### PR TITLE
Document SPA register with email confirmation

### DIFF
--- a/Documentation/content/1.getting-started/9.register-confirmed-account.md
+++ b/Documentation/content/1.getting-started/9.register-confirmed-account.md
@@ -1,0 +1,65 @@
+---
+title: Register a confirmed account
+description: SPA password and passkey signup when RequireConfirmedAccount is true.
+navigation:
+  icon: i-lucide-mail-check
+---
+
+Build a first-party SPA signup that stays logged out until the user confirms email, then signs in. Use this when `RequireConfirmedAccount` is `true` (the facade default).
+
+Assume the cookie facade: management and cookie login under `/identity`, passkeys under `/account`. See [Quick start](/getting-started/quick-start) and [Recipes](/composables/recipes).
+
+## Shared setup
+
+1. Offer **Password** and **Passkey** on the same signup screen.
+2. Call `GET /identity/csrfToken` before unsafe POSTs that require antiforgery. Send the value as header `RequestVerificationToken`.
+3. After a successful register (`200`), show the same **Check your email** screen for both methods. Do not treat that `200` as signed in.
+4. Do not tell the user the email is already registered. Duplicate-email paths return generic success or a generic failure (see below).
+
+## Password register
+
+1. Collect email and password.
+2. `POST /identity/register` with body `{ "email", "password" }` and CSRF.
+3. On `200`, show **Check your email**. Stay logged out. Duplicate email also returns `200` (anti-enumeration). Use the same copy.
+4. On validation failure, show the `400` problem details.
+5. The mail link calls `GET /identity/confirmEmail?userId=…&code=…`.
+   - With `EmailConfirmation.ConfirmEmailRedirectUri` unset: success is plain-text thank-you (`200`); failure is `401`.
+   - With the URI set: success and failure return `302` to that URI with `status=confirmed|failed` and `flow=confirm` (or `flow=change-email` when `changedEmail` is present). Configure the option under [Email confirmation](/getting-started/configuration#email-confirmation).
+6. After confirm, sign in: `POST /identity/login` with email and password. Use `?useSessionCookies=false` only when you need a persistent cookie. See [Cookie auth](/modules/cookie-auth).
+7. On login success, enter the app with the session cookie (`credentials: "include"`).
+
+## Passkey register
+
+1. Collect email only.
+2. `POST /account/passkeys/register/options` with `{ "email" }` and CSRF. Creation options are returned even when the email is already taken.
+3. Run `navigator.credentials.create(…)`. If the user cancels, show a soft UI error. Do not call register.
+4. `POST /account/passkeys/register?useCookies=true` with `{ "email", "credentialJson" }` and CSRF.
+5. New email success: `200` with `{ "credentialId" }` (or equivalent `PasskeyCredentialResponse`). No Identity application cookie while the account is unconfirmed. Show the same **Check your email** screen. You may add a short note that they registered with a passkey.
+6. Email taken, bad ceremony, or an attempt to attach to an existing user id: generic `400` **"Unable to complete registration."** Use that copy. Do not invent a more specific reason.
+7. Confirm with the same mail link and `GET /identity/confirmEmail` behavior as password register. The passkey is already stored on the unconfirmed user.
+8. After confirm, sign in with passkey:
+   1. `POST /account/passkeys/requestOptions` (optional `?username=`).
+   2. `navigator.credentials.get(…)`.
+   3. `POST /account/passkeys/login?useCookies=true` with the assertion payload and CSRF.
+9. Login succeeds only after confirm. Unconfirmed login returns `401` Invalid credentials.
+
+Default passkey completer cookie flags follow Identity `Login`, not facade `LoginCookie`. See [Passkeys](/modules/passkeys).
+
+## Host checklist
+
+| Do | Do not |
+| --- | --- |
+| Same check-email screen for password and passkey | Treat register `200` as logged in |
+| Generic copy on duplicate email | Say "email already registered" |
+| Sign in only after confirm | Expect a session from unconfirmed passkey register |
+
+## Out of scope
+
+This page does not cover sign-in inside `confirmEmail`, public resend without a session, or OAuth.
+
+## Related
+
+- [Identity management](/modules/identity-management)
+- [Passkeys](/modules/passkeys)
+- [Cookie auth](/modules/cookie-auth)
+- [Configuration](/getting-started/configuration#email-confirmation)

--- a/Documentation/content/3.modules/1.identity-management.md
+++ b/Documentation/content/3.modules/1.identity-management.md
@@ -68,3 +68,4 @@ Sensitive manage mutations require **antiforgery** and **ReAuth**.
 
 - [Composable requirements](/composables/requirements)
 - [ReAuth](/modules/reauth)
+- [Register a confirmed account](/getting-started/register-confirmed-account)

--- a/Documentation/content/3.modules/5.passkeys.md
+++ b/Documentation/content/3.modules/5.passkeys.md
@@ -55,6 +55,8 @@ Routes are mapped under `{prefix}/passkeys` (facade default `/account/passkeys`)
 
 A successful **user create** sends the same confirmation email as password `POST /register`. The account is not marked confirmed. Completers still skip a session when `CanSignInAsync` fails (for example `RequireConfirmedAccount`). Duplicate-email and failed-attestation paths do not send that mail. Passwordless register never attaches a passkey to an existing user id; add a credential to an existing account with authenticated `POST /passkeys/creationOptions` then `POST /passkeys/`.
 
+SPA password and passkey signup with a shared check-email screen: [Register a confirmed account](/getting-started/register-confirmed-account).
+
 ## Sign-in completer
 
 After a successful register/login ceremony, AuthEndpoints calls `IPasskeySignInCompleter<TUser>`.
@@ -110,3 +112,4 @@ Facade JWT opt-in does **not** auto-select the JWT completer — register it exp
 - [JWT](/modules/jwt)
 - [ReAuth](/modules/reauth)
 - [Configuration](/getting-started/configuration#passkeys)
+- [Register a confirmed account](/getting-started/register-confirmed-account)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a Getting Started how-to for SPA password and passkey signup when `RequireConfirmedAccount` is true: shared check-email screen, confirmEmail (including optional ConfirmEmailRedirectUri), then sign-in.

Coordinates with #253 / confirm-email redirect work: links [Email confirmation](/getting-started/configuration#email-confirmation). Prefer merging after that configuration section is on main so the anchor resolves.

Text only — no screenshots.

The configuration one-liner pointing at this how-to should land after #255 merges (`## Email confirmation` is not on main yet).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2fb3437-89c0-4afa-8219-86858fecebef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2fb3437-89c0-4afa-8219-86858fecebef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

