### PR TITLE
Bump AuthEndpoints to 3.0.7

### DIFF
--- a/Documentation/content/versions/v3.0.6.md
+++ b/Documentation/content/versions/v3.0.6.md
@@ -2,7 +2,6 @@
 title: v3.0.6
 description: Simple JWT refresh rotation is atomic under concurrent requests.
 date: 2026-09-07
-badge: Latest
 tag: v3.0.6
 ---
 

--- a/Documentation/content/versions/v3.0.7.md
+++ b/Documentation/content/versions/v3.0.7.md
@@ -1,0 +1,26 @@
+---
+title: v3.0.7
+description: Hosts can redirect browser email confirmation to an SPA route with status and flow query params.
+date: 2026-09-08
+badge: Latest
+tag: v3.0.7
+---
+
+### AuthEndpoints
+
+Hosts can redirect browser email confirmation to an SPA route with status and flow query params. Set `EmailConfirmation.ConfirmEmailRedirectUri` to a rooted path or an absolute URI so browser `GET` confirm-email returns `302` with `status` and `flow` instead of the thank-you body or `401`. Absolute URIs stay on `AllowedRedirectOrigins`. Unset hosts keep the existing text response.
+
+- Hosts can redirect browser email confirmation to an SPA route with `status` and `flow` query params
+- Absolute `ConfirmEmailRedirectUri` values stay on `AllowedRedirectOrigins`
+- Unset `ConfirmEmailRedirectUri` keeps the thank-you body or `401`
+
+### Packages
+
+- **AuthEndpoints** `3.0.7`
+- **AuthEndpoints.External.OAuth** unchanged at `3.0.0-preview.3`
+
+### Links
+
+- [GitHub release](https://github.com/madeyoga/AuthEndpoints/releases/tag/v3.0.7)
+- [Compare](https://github.com/madeyoga/AuthEndpoints/compare/v3.0.6...v3.0.7)
+- [Installation](/getting-started/installation)

--- a/src/AuthEndpoints/AuthEndpoints.csproj
+++ b/src/AuthEndpoints/AuthEndpoints.csproj
@@ -6,14 +6,14 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Description>Auth library that provides a set of minimal api endpoints to handle authentication actions</Description>
-    <Version>3.0.6</Version>
+    <Version>3.0.7</Version>
     <Authors>madeyoga</Authors>
     <Company>madeyoga</Company>
     <PackageProjectUrl>https://github.com/madeyoga/AuthEndpoints</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/madeyoga/AuthEndpoints</RepositoryUrl>
     <PackageTags>auth;endpoints;aspnetcore;jwt;passkey;webauthn;2fa;identity</PackageTags>
-    <PackageReleaseNotes>Simple JWT refresh rotation is atomic under concurrent requests.</PackageReleaseNotes>
+    <PackageReleaseNotes>Hosts can redirect browser email confirmation to an SPA route with status and flow query params.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump AuthEndpoints `3.0.6` → `3.0.7` and add the changelog page.

Hosts can redirect browser email confirmation to an SPA route with status and flow query params.

- AuthEndpoints `3.0.6` → `3.0.7`
- Docs changelog `v3.0.7` is Latest; `v3.0.6` no longer has that badge
- AuthEndpoints.External.OAuth remains `3.0.0-preview.3`

Does not create the GitHub release or tag. After merge, publish release `v3.0.7` to trigger NuGet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b10f573-e877-42d2-8147-215fe2995b65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b10f573-e877-42d2-8147-215fe2995b65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

